### PR TITLE
Implement code referencing when opening chat (#19) (WIP)

### DIFF
--- a/extensions/pearai-extension/lib/common/src/webview-api/ConversationSchema.ts
+++ b/extensions/pearai-extension/lib/common/src/webview-api/ConversationSchema.ts
@@ -20,6 +20,7 @@ export type Message = zod.infer<typeof messageSchema>;
 const messageExchangeContentSchema = zod.object({
 	type: zod.literal("messageExchange"),
 	messages: zod.array(messageSchema),
+	codeContexts: zod.array(selectionSchema).optional(),
 	error: errorSchema.optional(),
 	state: zod.discriminatedUnion("type", [
 		zod.object({

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
@@ -128,6 +128,9 @@ export class ChatController {
 	}
 
 	async createConversation(conversationTypeId: string) {
+		console.log("creating new conversation");
+
+
 		try {
 			const conversationType = this.getConversationType(conversationTypeId);
 
@@ -160,6 +163,31 @@ export class ChatController {
 				}
 
 				return;
+			}
+
+			// get selection if avaialble
+			if (vscode.window.activeTextEditor) {
+				const editor = vscode.window.activeTextEditor;
+
+				if (editor &&
+					editor.selection.end.isEqual(editor.selection.start) === false
+				) {
+					const selection = editor.selection
+					const text = editor.document.getText(
+						selection
+					).trim()
+
+					console.log("selection: ", selection);
+
+					const viewableContext: webviewApi.Selection = {
+						filename: editor.document.fileName,
+						text: text,
+						startLine: selection.start.line,
+						endLine: selection.end.line,
+					}
+
+					result.conversation.addCodeContext(viewableContext)
+				}
 			}
 
 			await this.addAndShowConversation(result.conversation);

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
@@ -130,7 +130,6 @@ export class ChatController {
 	async createConversation(conversationTypeId: string) {
 		console.log("creating new conversation");
 
-
 		try {
 			const conversationType = this.getConversationType(conversationTypeId);
 
@@ -169,13 +168,12 @@ export class ChatController {
 			if (vscode.window.activeTextEditor) {
 				const editor = vscode.window.activeTextEditor;
 
-				if (editor &&
+				if (
+					editor &&
 					editor.selection.end.isEqual(editor.selection.start) === false
 				) {
-					const selection = editor.selection
-					const text = editor.document.getText(
-						selection
-					).trim()
+					const selection = editor.selection;
+					const text = editor.document.getText(selection).trim();
 
 					console.log("selection: ", selection);
 
@@ -184,9 +182,9 @@ export class ChatController {
 						text: text,
 						startLine: selection.start.line,
 						endLine: selection.end.line,
-					}
+					};
 
-					result.conversation.addCodeContext(viewableContext)
+					result.conversation.addCodeContext(viewableContext);
 				}
 			}
 

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatPanel.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatPanel.ts
@@ -106,6 +106,10 @@ export class ChatPanel implements vscode.WebviewViewProvider {
 			conversations.push(await conversation.toWebviewConversation());
 		}
 
+		if (conversations.length > 0) {
+			console.log('updated conv: ', conversations[conversations.length - 1]);
+		}
+
 		const surfacePromptForOpenAIPlus = getConfigSurfacePromptForOpenAIPlus();
 		const hasOpenAIApiKey = await this.apiKeyManager.hasOpenAIApiKey();
 		this.state = {

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatPanel.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatPanel.ts
@@ -107,7 +107,7 @@ export class ChatPanel implements vscode.WebviewViewProvider {
 		}
 
 		if (conversations.length > 0) {
-			console.log('updated conv: ', conversations[conversations.length - 1]);
+			console.log("updated conv: ", conversations[conversations.length - 1]);
 		}
 
 		const surfacePromptForOpenAIPlus = getConfigSurfacePromptForOpenAIPlus();

--- a/extensions/pearai-extension/lib/extension/src/conversation/Conversation.ts
+++ b/extensions/pearai-extension/lib/extension/src/conversation/Conversation.ts
@@ -72,9 +72,9 @@ export class Conversation {
 			template.initialMessage == null
 				? { type: "userCanReply" }
 				: {
-					type: "waitingForBotAnswer",
-					botAction: template.initialMessage.placeholder ?? "Answering",
-				};
+						type: "waitingForBotAnswer",
+						botAction: template.initialMessage.placeholder ?? "Answering",
+					};
 	}
 
 	async getTitle() {
@@ -472,14 +472,14 @@ export class Conversation {
 	 * @param context Code snippets
 	 */
 	async addCodeContext(context: webviewApi.Selection) {
-		this.codeContexts.push(context)
+		this.codeContexts.push(context);
 	}
 
 	/**
 	 * Clears any code context from the current conversation & update view
 	 */
 	async clearCodeContext() {
-		this.codeContexts.length = 0
+		this.codeContexts.length = 0;
 	}
 
 	protected async addUserMessage({
@@ -534,20 +534,20 @@ export class Conversation {
 			content:
 				chatInterface === "message-exchange"
 					? {
-						type: "messageExchange",
-						messages: this.isTitleMessage()
-							? this.messages.slice(1)
-							: this.messages,
-						codeContexts: this.codeContexts,
-						state: this.state,
-						error: this.error,
-					}
+							type: "messageExchange",
+							messages: this.isTitleMessage()
+								? this.messages.slice(1)
+								: this.messages,
+							codeContexts: this.codeContexts,
+							state: this.state,
+							error: this.error,
+						}
 					: {
-						type: "instructionRefinement",
-						instruction: "", // TODO last user message?
-						state: this.refinementInstructionState(),
-						error: this.error,
-					},
+							type: "instructionRefinement",
+							instruction: "", // TODO last user message?
+							state: this.refinementInstructionState(),
+							error: this.error,
+						},
 		};
 	}
 

--- a/extensions/pearai-extension/lib/extension/src/extension.ts
+++ b/extensions/pearai-extension/lib/extension/src/extension.ts
@@ -10,6 +10,7 @@ import { indexRepository } from "./index/indexRepository";
 import { getVSCodeLogLevel, LoggerUsingVSCodeOutput } from "./logger";
 
 export const activate = async (context: vscode.ExtensionContext) => {
+	console.log("pearai activated")
 	const apiKeyManager = new ApiKeyManager({
 		secretStorage: context.secrets,
 	});
@@ -95,6 +96,8 @@ export const activate = async (context: vscode.ExtensionContext) => {
 			chatController.createConversation("generate-unit-test");
 		}),
 		vscode.commands.registerCommand("pearai.startChat", () => {
+			console.log("received start chat directive")
+
 			chatController.createConversation("chat-en");
 		}),
 		vscode.commands.registerCommand("pearai.editCode", () => {

--- a/extensions/pearai-extension/lib/extension/src/extension.ts
+++ b/extensions/pearai-extension/lib/extension/src/extension.ts
@@ -10,7 +10,7 @@ import { indexRepository } from "./index/indexRepository";
 import { getVSCodeLogLevel, LoggerUsingVSCodeOutput } from "./logger";
 
 export const activate = async (context: vscode.ExtensionContext) => {
-	console.log("pearai activated")
+	console.log("pearai activated");
 	const apiKeyManager = new ApiKeyManager({
 		secretStorage: context.secrets,
 	});
@@ -96,7 +96,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 			chatController.createConversation("generate-unit-test");
 		}),
 		vscode.commands.registerCommand("pearai.startChat", () => {
-			console.log("received start chat directive")
+			console.log("received start chat directive");
 
 			chatController.createConversation("chat-en");
 		}),

--- a/extensions/pearai-extension/lib/webview/package.json
+++ b/extensions/pearai-extension/lib/webview/package.json
@@ -7,6 +7,7 @@
     "@types/prismjs": "1.26.0",
     "@types/react": "18",
     "@types/react-dom": "18",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@types/vscode-webview": "1.57.0",
     "eslint": "^8.32.0",
     "eslint-plugin-react": "^7.32.1"
@@ -17,6 +18,7 @@
     "react": "18.2.0",
     "react-diff-viewer-continued": "3.2.5",
     "react-dom": "18.2.0",
-    "react-markdown": "8.0.5"
+    "react-markdown": "8.0.5",
+    "react-syntax-highlighter": "^15.5.0"
   }
 }

--- a/extensions/pearai-extension/lib/webview/src/component/ChatInput.tsx
+++ b/extensions/pearai-extension/lib/webview/src/component/ChatInput.tsx
@@ -1,4 +1,6 @@
+import { webviewApi } from "@pearai/common";
 import React, { useCallback, useRef } from "react";
+import { CodeContext } from "./CodeContext";
 
 export const ChatInput: React.FC<{
 	placeholder?: string;
@@ -7,6 +9,7 @@ export const ChatInput: React.FC<{
 	onChange?: (text: string) => void;
 	onSubmit?: (text: string) => void;
 	shouldCreateNewLineOnEnter?: boolean;
+	codeContexts?: webviewApi.Selection[];
 }> = ({
 	placeholder,
 	disabled,
@@ -14,6 +17,7 @@ export const ChatInput: React.FC<{
 	onChange,
 	onSubmit,
 	shouldCreateNewLineOnEnter,
+	codeContexts,
 }) => {
 	// callback to automatically focus the input box
 	const callbackRef = useCallback((inputElement: HTMLTextAreaElement) => {
@@ -29,6 +33,10 @@ export const ChatInput: React.FC<{
 
 	return (
 		<div className="chat-input" ref={textareaWrapperRef}>
+			{codeContexts?.map((context: webviewApi.Selection, i) => (
+				<CodeContext selection={context} key={i} />
+			))}
+
 			<textarea
 				disabled={disabled}
 				ref={callbackRef}

--- a/extensions/pearai-extension/lib/webview/src/component/CodeContext.tsx
+++ b/extensions/pearai-extension/lib/webview/src/component/CodeContext.tsx
@@ -1,0 +1,43 @@
+import { webviewApi } from "@pearai/common";
+import React from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+function getFileNameAndExtension(filePath: string) {
+	const fileNameWithExtension = filePath.split(/[/\\]/).pop() || "";
+	const ext = fileNameWithExtension.split(".").pop() || "";
+	const name = fileNameWithExtension.replace(`.${ext}`, "");
+
+	return { name, ext };
+}
+
+const extensionMap = new Map([
+	["js", "javascript"],
+	["ts", "typescript"],
+	["html", "html"],
+	["css", "css"],
+	["scss", "scss"],
+	["json", "json"],
+	["yaml", "yaml"],
+	["yml", "yaml"],
+	["md", "markdown"],
+]);
+
+export const CodeContext: React.FC<{
+	selection?: webviewApi.Selection;
+}> = ({ selection }) => {
+	const code = selection?.text || "missing";
+	const { name, ext } = getFileNameAndExtension(
+		selection?.filename || "bad.file"
+	);
+	const lang: string = extensionMap.get(ext) || "plaintext";
+
+	return (
+		<div className="code-context">
+			{name}.{ext}
+			<SyntaxHighlighter language={lang} style={docco}>
+				{code}
+			</SyntaxHighlighter>
+		</div>
+	);
+};

--- a/extensions/pearai-extension/lib/webview/src/component/CodeContext.tsx
+++ b/extensions/pearai-extension/lib/webview/src/component/CodeContext.tsx
@@ -1,7 +1,6 @@
 import { webviewApi } from "@pearai/common";
 import React from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 
 function getFileNameAndExtension(filePath: string) {
 	const fileNameWithExtension = filePath.split(/[/\\]/).pop() || "";
@@ -11,17 +10,18 @@ function getFileNameAndExtension(filePath: string) {
 	return { name, ext };
 }
 
-const extensionMap = new Map([
-	["js", "javascript"],
-	["ts", "typescript"],
-	["html", "html"],
-	["css", "css"],
-	["scss", "scss"],
-	["json", "json"],
-	["yaml", "yaml"],
-	["yml", "yaml"],
-	["md", "markdown"],
-]);
+const extensionMap: { [key: string]: string } = {
+	js: "javascript",
+	ts: "typescript",
+	json: "json",
+	py: "python",
+	java: "java",
+	cpp: "cpp",
+	c: "c",
+	cs: "csharp",
+	html: "html",
+	css: "css",
+};
 
 export const CodeContext: React.FC<{
 	selection?: webviewApi.Selection;
@@ -30,12 +30,12 @@ export const CodeContext: React.FC<{
 	const { name, ext } = getFileNameAndExtension(
 		selection?.filename || "bad.file"
 	);
-	const lang: string = extensionMap.get(ext) || "plaintext";
+	const lang: string = extensionMap[ext] || "plaintext";
 
 	return (
-		<div className="code-context">
+		<div className="syntax-highlighter-container">
 			{name}.{ext}
-			<SyntaxHighlighter language={lang} style={docco}>
+			<SyntaxHighlighter language={lang} showLineNumbers={true}>
 				{code}
 			</SyntaxHighlighter>
 		</div>

--- a/extensions/pearai-extension/lib/webview/src/component/MessageExchangeView.tsx
+++ b/extensions/pearai-extension/lib/webview/src/component/MessageExchangeView.tsx
@@ -61,6 +61,7 @@ export function MessageExchangeView({
 									onSendMessage(inputText);
 									setInputText("");
 								}}
+								codeContexts={content.codeContexts}
 							/>
 						);
 					default: {

--- a/extensions/pearai-extension/yarn.lock
+++ b/extensions/pearai-extension/yarn.lock
@@ -150,7 +150,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/runtime@^7.7.2":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.7.2":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
   integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
@@ -679,6 +679,13 @@
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-syntax-highlighter@^15.5.13":
+  version "15.5.13"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz#c5baf62a3219b3bf28d39cfea55d0a49a263d1f2"
+  integrity sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==
   dependencies:
     "@types/react" "*"
 
@@ -1211,10 +1218,25 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
 character-entities@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 check-error@^1.0.3:
   version "1.0.3"
@@ -1355,6 +1377,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
+  integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
 comma-separated-tokens@^2.0.0:
   version "2.0.3"
@@ -2057,6 +2084,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
@@ -2137,6 +2171,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -2331,10 +2370,31 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
+  integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
 hast-util-whitespace@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz#0ec64e257e6fc216c7d14c8a1b74d27d650b4557"
   integrity sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==
+
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 hosted-git-info@^4.0.2:
   version "4.1.0"
@@ -2434,6 +2494,19 @@ internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-array-buffer@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.4.tgz#7a1f92b3d61edd2bc65d24f130530ea93d7fae98"
@@ -2507,6 +2580,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
@@ -2547,6 +2625,11 @@ is-glob@^4.0.0, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-interactive@^1.0.0:
   version "1.0.0"
@@ -3001,6 +3084,14 @@ loupe@^2.3.6:
   integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
   dependencies:
     get-func-name "^2.0.1"
+
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3674,6 +3765,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -3835,10 +3938,15 @@ pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prismjs@1.29.0:
+prismjs@1.29.0, prismjs@^1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 prop-types@^15.0.0, prop-types@^15.8.1:
   version "15.8.1"
@@ -3848,6 +3956,13 @@ prop-types@^15.0.0, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^5.0.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
+  integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
+  dependencies:
+    xtend "^4.0.0"
 
 property-information@^6.0.0:
   version "6.5.0"
@@ -3949,6 +4064,17 @@ react-markdown@8.0.5:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
+react-syntax-highlighter@^15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz#4b3eccc2325fa2ec8eff1e2d6c18fa4a9e07ab20"
+  integrity sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -3984,6 +4110,15 @@ reflect.getprototypeof@^1.0.4:
     get-intrinsic "^1.2.4"
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
+
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
 
 regenerator-runtime@^0.14.0:
   version "0.14.1"
@@ -4281,6 +4416,11 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
+  integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -4974,6 +5114,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
**CURRENTLY WIP**

The goals are to be able to select code and have it contextualized to the next user question.
This PR is based on issue #19 


### Todo
- [x] Send code selection to new conversation
- [ ] Code view should reflect current VSCode theming
- [ ] Be able to remove code snippet from message

### Bonus
- [ ] Shortcut to load more code snippets to message context
- [ ] Implement along side #44 , similarly to cursor code referencing

### Ideas
- Use manaco editor as a read-only viewer for code/context snippets
- Use vscode css variables to set token highlighting colors
- Use styled markdown instead of editor (this should simplify implementation)