### PR TITLE
Fix issue #59 - Update contributing.md doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,9 @@ If the build step fails, or if the built version fails to run (see next section)
 
 #### Errors and Warnings
 
-Errors and warnings will show in the console while developing VS Code. If you use VS Code to develop VS Code, errors and warnings are shown in the status bar at the bottom left of the editor. You can view the error list using `View | Errors and Warnings` or pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> and then <kbd>!</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> and <kbd>!</kbd> on macOS).
+Errors and warnings will show in the console while developing the PearAI App. If you use VS Code to develop the PearAI App, errors and warnings are shown in the status bar at the bottom left of the editor. You can view the error list using `View | Errors and Warnings` or pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> and then <kbd>!</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> and <kbd>!</kbd> on macOS).
 
-👉 **Tip!** You don't need to stop and restart the development version of VS Code after each change. You can just execute `Reload Window` from the command palette. We like to assign the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>R</kbd> (<kbd>CMD</kbd>+<kbd>R</kbd> on macOS) to this command.
+👉 **Tip!** You don't need to stop and restart the development version of the PearAI App after each change. You can just execute `Reload Window` from the command palette. We like to assign the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>R</kbd> (<kbd>CMD</kbd>+<kbd>R</kbd> on macOS) to this command.
 
 ### Run
 
@@ -226,9 +226,9 @@ UI in the browser, extensions run in code server (NodeJS):
 .\scripts\code-server.bat --launch
 ```
 
-You can identify the development version of VS Code ("Code - OSS") by the following icon in the Dock or Taskbar:
+You can identify the development version of the PearAI App ("Code - OSS") by the following icon in the Dock or Taskbar:
 
-[![VS Code default icon](https://i.imgur.com/D2CeX0y.png)](https://i.imgur.com/D2CeX0y.png)
+[![PearAI App default icon](https://i.imgur.com/D2CeX0y.png)](https://i.imgur.com/D2CeX0y.png)
 
 ### Debugging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,12 +96,12 @@ To fix this error open Visual Studio Installer, add the following components cor
 
 ### Development container
 
-Alternatively, you can avoid local dependency installation as this repository includes a Visual Studio Code Remote - Containers / Codespaces [development container](https://github.com/microsoft/vscode/tree/main/.devcontainer).
+Alternatively, you can avoid local dependency installation as this repository includes a Visual Studio Code Remote - Containers / Codespaces [development container](https://github.com/trypear/pearai-app/tree/main/.devcontainer).
 
 - For [Remote - Containers](https://aka.ms/vscode-remote/download/containers), use the **Remote-Containers: Open Repository in Container...** command which creates a Docker volume for better disk I/O on macOS and Windows.
 - For Codespaces, install the [GitHub Codespaces](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) extension in VS Code, and use the **Codespaces: Create New Codespace** command.
 
-Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run the full build. See the [development container README](https://github.com/microsoft/vscode/blob/main/.devcontainer/README.md) for more information.
+Docker / the Codespace should have at least **4 Cores and 6 GB of RAM (8 GB recommended)** to run the full build. See the [development container README](https://github.com/trypear/pearai-app/blob/main/.devcontainer/README.md) for more information.
 
 If you'd like to contribute to the list of available development containers in the Remote - Containers extension, you can check out the [Contributing documentation](https://github.com/microsoft/vscode-dev-containers/blob/master/CONTRIBUTING.md) in the vscode-dev-containers repo.
 
@@ -255,13 +255,13 @@ The **search** process can be debugged, but must first be started. Before attemp
 
 ### Automated Testing
 
-Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
+Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/trypear/pearai-app/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
 
-We also have automated UI tests. The [smoke test README](https://github.com/Microsoft/vscode/blob/main/test/smoke/README.md) has all the details.
+We also have automated UI tests. The [smoke test README](https://github.com/trypear/pearai-app/blob/main/test/smoke/README.md) has all the details.
 
 ### Unit Testing
 
-Run the tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
+Run the tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/trypear/pearai-app/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
 
 ### Linting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to Pear AI
 
 ## Table of Contents
+
 1. [Prerequisites](#prerequisites)
 2. [Troubleshooting](#troubleshooting)
 3. [Development container](#development-container)
@@ -31,11 +32,11 @@ PearAI is a fork of VSCode, so simply follow VSCode's guide for running the app.
 
 The extension can be run in two ways:
 
-RECOMMENDED: Internally within the main PearAI application (which is a VSCode fork): https://github.com/trypear/pearai/. This guide is for running it internally.
+RECOMMENDED: Internally within the main PearAI application (which is a VSCode fork): <https://github.com/trypear/pearai/>. This guide is for running it internally.
 
 Standalone as an extension. For running it standalone, you will want to `cd` into `extensions/pearai-extension` and visit [Contributing to pearai-extension](extensions/pearai-extension/CONTRIBUTING.md)
 
-After cloning and building the repo, check out the [issues list](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue). Issues labeled [`help wanted`](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are good issues to submit a PR for. Issues labeled [`good first issue`](https://github.com/Microsoft/vscode/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are great candidates to pick up if you are in the code for the first time. If you are contributing significant changes, or if the issue is already assigned to a specific month milestone, please discuss with the assignee of the issue first before starting to work on the issue.
+After cloning and building the repo, check out the [issues list](https://github.com/trypear/pearai-app/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue). Issues labeled [`help wanted`](https://github.com/trypear/pearai-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are good issues to submit a PR for. Issues labeled [`good first issue`](https://github.com/trypear/pearai-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are great candidates to pick up if you are in the code for the first time. If you are contributing significant changes, or if the issue is already assigned to a specific month milestone, please discuss with the assignee of the issue first before starting to work on the issue.
 
 ## Prerequisites
 
@@ -58,20 +59,21 @@ You'll need the following tools:
         - open a command prompt and run `npm config set msvs_version {visual studio version}`. (If you are using Visual Studio 2019 then you need to run `npm config set msvs_version 2019`)
     - **Warning:** Make sure your profile path only contains ASCII letters, e.g. *John*, otherwise, it can lead to [node-gyp usage problems (nodejs/node-gyp/issues#297)](https://github.com/nodejs/node-gyp/issues/297)
     - **Note**: Building and debugging via the Windows subsystem for Linux (WSL) is currently not supported.
-  - **Windows WSL2**: https://github.com/microsoft/vscode/wiki/Selfhosting-on-Windows-WSL
+  - **Windows WSL2**: <https://github.com/microsoft/vscode/wiki/Selfhosting-on-Windows-WSL>
   - **macOS**
     - [Xcode](https://developer.apple.com/xcode/resources/) and the Command Line Tools, which will install `gcc` and the related toolchain containing `make`
       - Run `xcode-select --install` to install the Command Line Tools
   - **Linux**
-    * On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3`
-    * On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel krb5-devel # or .i686`.
-    * Others:
-      * `make`
-      * [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
-      * [GCC](https://gcc.gnu.org) or another compile toolchain
-    * Building deb and rpm packages requires `fakeroot` and `rpm`; run: `sudo apt-get install fakeroot rpm`
+    - On Debian-based Linux: `sudo apt-get install build-essential g++ libx11-dev libxkbfile-dev libsecret-1-dev libkrb5-dev python-is-python3`
+    - On Red Hat-based Linux: `sudo yum groupinstall "Development Tools" && sudo yum install libX11-devel.x86_64 libxkbfile-devel.x86_64 libsecret-devel krb5-devel # or .i686`.
+    - Others:
+      - `make`
+      - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
+      - [GCC](https://gcc.gnu.org) or another compile toolchain
+    - Building deb and rpm packages requires `fakeroot` and `rpm`; run: `sudo apt-get install fakeroot rpm`
 
 ### Troubleshooting
+
 In case of issues, try deleting the contents of `~/.node-gyp` (alternatively `~/.cache/node-gyp` for Linux, `~/Library/Caches/node-gyp/` for macOS, or `%USERPROFILE%\AppData\Local\node-gyp` for Windows) first and then run `yarn cache clean` and then try again.
 
 > If you are on Windows or Linux 64 bit systems and would like to compile to 32 bit, you'll need to set the `npm_config_arch` environment variable to `ia32` before running `yarn`. This will compile all native node modules for a 32 bit architecture. Similarly, when cross-compiling for ARM, set `npm_config_arch` to `arm`.
@@ -111,42 +113,42 @@ Otherwise, if you're a member of the VS Code team, follow the [Commit Signing](h
 
 ## Build and Run
 
-If you want to understand how VS Code works or want to debug an issue, you'll want to get the source, build it, and run the tool locally.
+If you want to understand how the PearAI App works or want to debug an issue, you'll want to get the source, build it, and run the tool locally.
 
 > NOTE: If you need to debug the 32bit version of VS Code on 64bit Windows, follow [the guide on how to do that](https://github.com/microsoft/vscode/wiki/Build-and-run-32bit-Code---OSS-on-Windows).
 
 ### Getting the sources
 
-First, fork the VS Code repository so that you can make a pull request. Then, clone your fork locally:
+First, fork the `trypear/pearai-app` repository so that you can make pull requests. Then, clone your fork locally:
 
 ```
-git clone https://github.com/<<<your-github-account>>>/vscode.git
+git clone https://github.com/<<<your-github-account>>>/pearai-app.git
 ```
 
 Occasionally you will want to merge changes in the upstream repository (the official code repo) with your fork.
 
 ```
-cd vscode
+cd pearai-app
 git checkout main
-git pull https://github.com/microsoft/vscode.git main
+git pull https://github.com/trypear/pearai-app.git main
 ```
 
 Manage any merge conflicts, commit them, and then push them to your fork.
 
-**Note**: The `microsoft/vscode` repository contains a collection of GitHub Actions that help us with triaging issues. As you probably don't want these running on your fork, you can disable Actions for your fork via `https://github.com/<<Your Username>>/vscode/settings/actions`.
+**Note**: The `trypear/pearai-app` repository contains a collection of GitHub Actions that help us with triaging issues. They are disabled by default, but you can enable them for your fork via `https://github.com/<<Your Username>>/pearai-app/actions`.
 
 ### Build
 
 Install and build all of the dependencies using `Yarn`:
 
 ```
-cd vscode
+cd pearai-app
 yarn
 ```
 
 Then you have two options:
 
-- If you want to build from inside VS Code, you can open the `vscode` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close VS Code. If you happen to close VS Code and open it again, just resume the build by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>) again. You can kill it by running the `Kill Build VS Code` task or pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> in the task terminal.
+- If you want to build from inside VS Code, you can open the `pearai-app` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close the app.
 - If you want to build from a terminal, run `yarn watch`. This will run both the core watch task and watch-extension tasks in a single terminal.
 
 The incremental builder will do an initial full build and will display a message that includes the phrase "Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
@@ -156,18 +158,19 @@ The incremental builder will do an initial full build and will display a message
 - **Windows:** If you have installed Visual Studio 2017 as your build tool, you need to open **x64 Native Tools Command Prompt for VS 2017**. Do not confuse it with *VS2015 x64 Native Tools Command Prompt*, if installed.
 - **Linux:** You may hit a ENOSPC error when running the build. To get around this follow instructions in the [Common Questions](https://code.visualstudio.com/docs/setup/linux#_common-questions).
 
-If the build step fails, or if the built version fails to run (see next section), run `git clean -xfd` in your `vscode` folder, then re-run `yarn`.
+If the build step fails, or if the built version fails to run (see next section), run `git clean -xfd` in your `pearai-app` folder, then re-run `yarn`.
 
 #### Errors and Warnings
+
 Errors and warnings will show in the console while developing VS Code. If you use VS Code to develop VS Code, errors and warnings are shown in the status bar at the bottom left of the editor. You can view the error list using `View | Errors and Warnings` or pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> and then <kbd>!</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> and <kbd>!</kbd> on macOS).
 
 👉 **Tip!** You don't need to stop and restart the development version of VS Code after each change. You can just execute `Reload Window` from the command palette. We like to assign the keyboard shortcut <kbd>Ctrl</kbd>+<kbd>R</kbd> (<kbd>CMD</kbd>+<kbd>R</kbd> on macOS) to this command.
 
 ### Run
 
-To test the changes, you launch a development version of VS Code on the workspace `vscode`, which you are currently editing.
+To test the changes, you launch a development version of the PearAI-App on the workspace `pearai-app`, which you are currently editing.
 
-To test changes with a remote, use the "TestResolver" in your Code - OSS window which creates a fake remote window. Search Command Palette for `TestResolver`. More information is at https://github.com/microsoft/vscode/issues/162874#issuecomment-1271774905.
+To test changes with a remote, use the "TestResolver" in your Code - OSS window which creates a fake remote window. Search Command Palette for `TestResolver`. More information is at <https://github.com/microsoft/vscode/issues/162874#issuecomment-1271774905>.
 
 #### Desktop
 
@@ -206,6 +209,7 @@ Extensions and UI run in the browser.
 ```bat
 .\scripts\code-web.bat
 ```
+
 #### Code Server Web
 
 UI in the browser, extensions run in code server (NodeJS):
@@ -226,21 +230,22 @@ You can identify the development version of VS Code ("Code - OSS") by the follow
 
 [![VS Code default icon](https://i.imgur.com/D2CeX0y.png)](https://i.imgur.com/D2CeX0y.png)
 
-
 ### Debugging
+
 VS Code has a multi-process architecture and your code is executed in different processes.
 
 The **render** process runs the UI code inside the Shell window. To debug code running in the **render** you can either use VS Code or the Chrome Developer Tools.
 
-#### Using VS Code
-* Open the `vscode` repository folder
-* Choose the `VS Code` launch configuration from the launch dropdown in the Debug viewlet and press <kbd>F5</kbd>.
+#### Using the PearAI-App
 
+- Open the `pearai-app` repository folder
+
+- Choose the `VS Code` launch configuration from the launch dropdown in the Debug viewlet and press <kbd>F5</kbd>.
 
 #### Using the Chrome Developer Tools
 
-* Run the `Developer: Toggle Developer Tools` command from the Command Palette in your development instance of VS Code to launch the Chrome tools.
-* It's also possible to debug the released versions of VS Code, since the sources link to sourcemaps hosted online.
+- Run the `Developer: Toggle Developer Tools` command from the Command Palette in your development instance of VS Code to launch the Chrome tools.
+- It's also possible to debug the released versions of VS Code, since the sources link to sourcemaps hosted online.
 
 [![sourcemaps](http://i.imgur.com/KU3TdjO.png)](http://i.imgur.com/KU3TdjO.png)
 
@@ -249,42 +254,51 @@ The **extension host** process runs code implemented by a plugin. To debug exten
 The **search** process can be debugged, but must first be started. Before attempting to attach, start a search by pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> on macOS), otherwise, attaching will fail and time out.
 
 ### Automated Testing
-Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `vscode` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
+
+Run the unit tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
 
 We also have automated UI tests. The [smoke test README](https://github.com/Microsoft/vscode/blob/main/test/smoke/README.md) has all the details.
 
 ### Unit Testing
-Run the tests directly from a terminal by running `./scripts/test.sh` from the `vscode` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
+
+Run the tests directly from a terminal by running `./scripts/test.sh` from the `pearai-app` folder (`scripts\test` on Windows). The [test README](https://github.com/Microsoft/vscode/blob/main/test/README.md) has complete details on how to run and debug tests, as well as how to produce coverage reports.
 
 ### Linting
-We use [eslint](https://eslint.org/) for linting our sources. You can run eslint across the sources by calling `yarn eslint` from a terminal or command prompt. You can also run `yarn eslint` as a VS Code task by pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> on macOS) and entering `task eslint`.
+
+We use [eslint](https://eslint.org/) for linting our sources. You can run eslint across the sources by calling `yarn eslint` from a terminal or command prompt. You can also run `yarn eslint` as a task by pressing <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>CMD</kbd>+<kbd>P</kbd> on macOS) and entering `task eslint`.
 
 To lint the source as you make changes you can install the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 
 ### Extensions
-The Visual Studio Marketplace is not available from the `vscode` open source builds. If you need to use or debug an extension you can check to see if the extension author publishes builds in their repository (check the `Builds` page) or if it is open source you can clone and build the extension locally. Once you have the .VSIX, you can "side load" the extension either through the command line or using __Install from VSIX__ command in the Extensions View command drop-down ([see more](https://code.visualstudio.com/docs/editor/extension-gallery#_command-line-extension-management) on command line extension management).
+
+The Visual Studio Marketplace is not available from the `pearai-app` open source builds. If you need to use or debug an extension you can check to see if the extension author publishes builds in their repository (check the `Builds` page) or if it is open source you can clone and build the extension locally. Once you have the .VSIX, you can "side load" the extension either through the command line or using **Install from VSIX** command in the Extensions View command drop-down ([see more](https://code.visualstudio.com/docs/editor/extension-gallery#_command-line-extension-management) on command line extension management).
 
 ## Work Branches
-Even if you have push rights on the Microsoft/vscode repository, you should create a personal fork and create feature branches there when you need them. This keeps the main repository clean and your personal workflow cruft out of sight.
+
+Even if you have push rights on the trypear/pearai-app repository, you should create a personal fork and create feature branches there when you need them. This keeps the main repository clean and your personal workflow cruft out of sight.
 
 ## Pull Requests
+
 Before we can accept a pull request from you, you'll need to sign a [[Contributor License Agreement (CLA)|Contributor-License-Agreement]]. It is an automated process and you only need to do it once.
 
 To enable us to quickly review and accept your pull requests, always create one pull request per issue and [link the issue in the pull request](https://github.com/blog/957-introducing-issue-mentions). Never merge multiple requests in one unless they have the same root cause. Be sure to follow our [[Coding Guidelines|Coding-Guidelines]] and keep code changes as small as possible. Avoid pure formatting changes to code that has not been modified otherwise. Pull requests should contain tests whenever possible.
 
 ### Introducing usage of new Electron API with a PR
+
 A pull request that depends on Electron API that VS Code is currently not using comes with a certain risk and may be rejected. Whenever we update Electron, there is a chance that less popular Electron APIs break and it is very hard to find out upfront. Once a PR lands in VS Code, the role of maintaining the feature moves to the team and as such we have to follow up with upstream components to ensure the feature is still supported. As such, as a rule of thumb:
-* avoid Electron APIs and use web standards instead (this also ensures that your feature is supported in our web client)
-* if you must use Electron APIs, we require a unit test at https://github.com/electron/electron so that we protect against future breakage.
+
+- avoid Electron APIs and use web standards instead (this also ensures that your feature is supported in our web client)
+- if you must use Electron APIs, we require a unit test at <https://github.com/electron/electron> so that we protect against future breakage.
 
 ### Where to Contribute
-Check out the [full issues list](https://github.com/Microsoft/vscode/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue) for a list of all potential areas for contributions. Note that just because an issue exists in the repository does not mean we will accept a contribution to the core editor for it. There are several reasons we may not accept a pull request like:
 
-* Performance - One of Visual Studio Code's core values is to deliver a *lightweight* code editor, that means it should perform well in both real and perceived performance.
-* User experience - Since we want to deliver a *lightweight* code editor, the UX should feel lightweight as well and not be cluttered. Most changes to the UI should go through the issue owner and/or the UX team.
-* Architectural - The team and/or feature owner needs to agree with any architectural impact a change may make. Things like new extension APIs *must* be discussed with and agreed upon by the feature owner.
+Check out the [full issues list](https://github.com/trypear/pearai-app/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue) for a list of all potential areas for contributions. Note that just because an issue exists in the repository does not mean we will accept a contribution to the core editor for it. There are several reasons we may not accept a pull request like:
 
-To improve the chances to get a pull request merged you should select an issue that is labelled with the [`help-wanted`](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`bug`](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) labels. If the issue you want to work on is not labelled with `help-wanted` or `bug`, you can start a conversation with the issue owner asking whether an external contribution will be considered.
+- Performance - One of Visual Studio Code's core values is to deliver a *lightweight* code editor, that means it should perform well in both real and perceived performance.
+- User experience - Since we want to deliver a *lightweight* code editor, the UX should feel lightweight as well and not be cluttered. Most changes to the UI should go through the issue owner and/or the UX team.
+- Architectural - The team and/or feature owner needs to agree with any architectural impact a change may make. Things like new extension APIs *must* be discussed with and agreed upon by the feature owner.
+
+To improve the chances to get a pull request merged you should select an issue that is labelled with the [`help-wanted`](https://github.com/trypear/pearai-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [`good first issue`](https://github.com/trypear/pearai-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) labels.
 
 To avoid multiple pull requests resolving the same issue, let others know you are working on it by saying so in a comment.
 
@@ -294,21 +308,23 @@ Pull requests that fix spell check errors in **translatable strings** (strings i
 
 ## Packaging
 
-VS Code can be packaged for the following platforms: `win32-ia32 | win32-x64 | darwin-x64 | darwin-arm64 | linux-ia32 | linux-x64 | linux-arm`
+PearAI-App can be packaged for the following platforms: `win32-ia32 | win32-x64 | darwin-x64 | darwin-arm64 | linux-ia32 | linux-x64 | linux-arm`
 
 These `gulp` tasks are available:
 
-* `vscode-[platform]`: Builds a packaged version for `[platform]`.
-* `vscode-[platform]-min`: Builds a packaged and minified version for `[platform]`.
+- `vscode-[platform]`: Builds a packaged version for `[platform]`.
+- `vscode-[platform]-min`: Builds a packaged and minified version for `[platform]`.
 
 👉 **Tip!** Run `gulp` via `yarn` to avoid potential out of memory issues, for example `yarn gulp vscode-linux-x64`
 
 See also: [Cross-Compiling for Debian-based Linux](https://github.com/Microsoft/vscode/wiki/Cross-Compiling-for-Debian-Based-Linux)
 
 ## Suggestions
-We're also interested in your feedback for the future of VS Code. You can submit a suggestion or feature request through the issue tracker. To make this process more effective, we're asking that these include more information to help define them more clearly.
+
+We're also interested in your feedback for the future of the PearAI App. You can submit a suggestion or feature request through the issue tracker. To make this process more effective, we're asking that these include more information to help define them more clearly.
 
 ## Translations
+
 We accept feedback on translations in language packs via GitHub issues in our [localization repo](https://github.com/Microsoft/vscode-loc/issues) that contains our currently supported language packs.
 
 ## Discussion Etiquette
@@ -335,6 +351,7 @@ To submit a pull request, follow the following steps:
 5. Await review. Respond to any comments or requests made by reviewers.
 
 ## Important Notes
+
 1. Please do not edit the structure of the repo. Pear is constantly changing, and we want to make sure that we can easily integrate your changes into our codebase.
 
 ## Coding Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,6 @@ The extension can be run in two ways:
 
 RECOMMENDED: Internally within the main PearAI application (which is a VSCode fork): <https://github.com/trypear/pearai/>. This guide is for running it internally.
 
-Standalone as an extension. For running it standalone, you will want to `cd` into `extensions/pearai-extension` and visit [Contributing to pearai-extension](extensions/pearai-extension/CONTRIBUTING.md)
-
 After cloning and building the repo, check out the [issues list](https://github.com/trypear/pearai-app/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue). Issues labeled [`help wanted`](https://github.com/trypear/pearai-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are good issues to submit a PR for. Issues labeled [`good first issue`](https://github.com/trypear/pearai-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are great candidates to pick up if you are in the code for the first time. If you are contributing significant changes, or if the issue is already assigned to a specific month milestone, please discuss with the assignee of the issue first before starting to work on the issue.
 
 ## Prerequisites
@@ -148,7 +146,7 @@ yarn
 
 Then you have two options:
 
-- If you want to build from inside VS Code, you can open the `pearai-app` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close the app.
+- If you want to build from inside VS Code, you can open the `pearai-app` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close the app. If you happen to close VS Code and open it again, just resume the build by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd>) again. You can kill it by running the `Kill Build VS Code` task or pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> in the task terminal.
 - If you want to build from a terminal, run `yarn watch`. This will run both the core watch task and watch-extension tasks in a single terminal.
 
 The incremental builder will do an initial full build and will display a message that includes the phrase "Finished compilation" once the initial build is complete. The builder will watch for file changes and compile those changes incrementally, giving you a fast, iterative coding experience.
@@ -168,7 +166,7 @@ Errors and warnings will show in the console while developing the PearAI App. If
 
 ### Run
 
-To test the changes, you launch a development version of the PearAI-App on the workspace `pearai-app`, which you are currently editing.
+To test the changes, you launch a development version of the PearAI App on the workspace `pearai-app`, which you are currently editing.
 
 To test changes with a remote, use the "TestResolver" in your Code - OSS window which creates a fake remote window. Search Command Palette for `TestResolver`. More information is at <https://github.com/microsoft/vscode/issues/162874#issuecomment-1271774905>.
 
@@ -226,9 +224,7 @@ UI in the browser, extensions run in code server (NodeJS):
 .\scripts\code-server.bat --launch
 ```
 
-You can identify the development version of the PearAI App ("Code - OSS") by the following icon in the Dock or Taskbar:
-
-[![PearAI App default icon](https://i.imgur.com/D2CeX0y.png)](https://i.imgur.com/D2CeX0y.png)
+You can identify the development version of the PearAI App by finding the Pear logo in your Dock or Taskbar.
 
 ### Debugging
 
@@ -236,7 +232,7 @@ VS Code has a multi-process architecture and your code is executed in different 
 
 The **render** process runs the UI code inside the Shell window. To debug code running in the **render** you can either use VS Code or the Chrome Developer Tools.
 
-#### Using the PearAI-App
+#### Using the PearAI App
 
 - Open the `pearai-app` repository folder
 
@@ -308,7 +304,7 @@ Pull requests that fix spell check errors in **translatable strings** (strings i
 
 ## Packaging
 
-PearAI-App can be packaged for the following platforms: `win32-ia32 | win32-x64 | darwin-x64 | darwin-arm64 | linux-ia32 | linux-x64 | linux-arm`
+The PearAI App can be packaged for the following platforms: `win32-ia32 | win32-x64 | darwin-x64 | darwin-arm64 | linux-ia32 | linux-x64 | linux-arm`
 
 These `gulp` tasks are available:
 


### PR DESCRIPTION
This PR addresses the issue outlined in `Improve 'Get Started Deving' Onboarding` #59 

I have updated the CONTRIBUTING.md file to reflect the transition from 'vscode' to 'pearai-app'.  Most links have been modified to point to the pearai-app repository, unless it is specific to VSCodes troubleshooting or build fixes, to which I have left them unchanged. 

There are still some things that need to be rewritten or removed.

**Sections** in the doc that need modifying or removal (that I can see):

- Introducing usage of new Electron API with a PR: Replace `VS Code` with `PearAI App`?
- Spell check errors: Language features; may need to be written, link is for original wiki.
- Enable Commit Signing: removal?
- Debugging: Rewrite working. Should `VS Code `be replaced with `PearAI App`?
- Where to Contribute: performance / user experience / architectural needs a rewrite

Additionally:
- Links: All wiki links point to VSCode's original repo still, as the pearai-app repo doesn't have those pages. #