### PR TITLE
Implement issue #20

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -148,7 +148,7 @@ MenuRegistry.appendMenuItems([
 
 export class ResizeAuxiliaryBarWidthAction extends Action2 {
 	static readonly ID = 'workbench.action.resizeAuxiliaryBarWidth';
-	static readonly LABEL = localize('resizeAuxiliaryBarWidth', "Resize Auxiliary Bar Width");
+	static readonly LABEL = localize2('resizeAuxiliaryBarWidth', "Resize Auxiliary Bar Width");
 
 	// Tracking the previous width of the aux bar and visibility of the left side bar
 	static _previousAuxiliaryBarWidth: number | null = null;
@@ -157,7 +157,7 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 	constructor() {
 		super({
 			id: ResizeAuxiliaryBarWidthAction.ID,
-			title: localize2('resizeAuxiliaryBarWidth', "Resize Auxiliary Bar Width"),
+			title: ResizeAuxiliaryBarWidthAction.LABEL,
 			category: Categories.View,
 			f1: true,
 			keybinding: {
@@ -176,11 +176,11 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor): Promise<void> {
+	run(accessor: ServicesAccessor): void {
 		const layoutService = accessor.get(IWorkbenchLayoutService);
 		// Check if the main window is available
 		if (!mainWindow) {
-			return Promise.resolve();
+			return;
 		}
 
 		const auxBarPart = layoutService.getContainer(mainWindow, Parts.AUXILIARYBAR_PART);
@@ -189,7 +189,7 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 
 		// If the auxiliary bar is not visible, or the dimensions are null, return
 		if (!auxBarDimensions || !isAuxiliaryBarVisible) {
-			return Promise.resolve();
+			return;
 		}
 
 		// Save the current width as the previous width if it has not been saved yet
@@ -222,7 +222,7 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 			ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth = null;
 		}
 
-		return Promise.resolve();
+		return;
 	}
 }
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -146,12 +146,13 @@ MenuRegistry.appendMenuItems([
 	}
 ]);
 
-// Previous states for side bar and auxiliary bar
-let _previousAuxiliaryBarWidth: number | null = null;
-let _previousSideBarVisibility: boolean | null = null;
 export class ResizeAuxiliaryBarWidthAction extends Action2 {
 	static readonly ID = 'workbench.action.resizeAuxiliaryBarWidth';
 	static readonly LABEL = localize('resizeAuxiliaryBarWidth', "Resize Auxiliary Bar Width");
+
+	// Tracking the previous width of the aux bar and visibility of the left side bar
+	static _previousAuxiliaryBarWidth: number | null = null;
+	static _previousSideBarVisibility: boolean | null = null;
 
 	constructor() {
 		super({
@@ -192,9 +193,9 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 		}
 
 		// Save the current width as the previous width if it has not been saved yet
-		if (_previousAuxiliaryBarWidth === null) {
-			_previousAuxiliaryBarWidth = auxBarDimensions.width;
-			_previousSideBarVisibility = layoutService.isVisible(Parts.SIDEBAR_PART);
+		if (ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth === null) {
+			ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth = auxBarDimensions.width;
+			ResizeAuxiliaryBarWidthAction._previousSideBarVisibility = layoutService.isVisible(Parts.SIDEBAR_PART);
 		}
 
 		// Set a minimum width for the auxiliary bar, unless its greater than a % of the window width
@@ -204,21 +205,21 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 		// 70% of the window width is the maximum width
 		const maxWidth = (0.7 * mainWindow.innerWidth);
 		// The minimum width is the maximum width, unless it is less than the max of (previous width * 2) or the predetermined minimum width
-		const minWidth = Math.min(maxWidth, Math.max(_previousAuxiliaryBarWidth * 2, PSEUDO_MINIMUM_AUX_BAR_WIDTH));
+		const minWidth = Math.min(maxWidth, Math.max(ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth * 2, PSEUDO_MINIMUM_AUX_BAR_WIDTH));
 
 		// If the current width is less than or equal to the previous width, expand the auxiliary bar
-		if (auxBarDimensions.width <= _previousAuxiliaryBarWidth) {
+		if (auxBarDimensions.width <= ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth) {
 			// Expand to the calculated minWidth
 			layoutService.resizePart(Parts.AUXILIARYBAR_PART, (minWidth - auxBarDimensions.width), 0);
 			// Hide the left side bar if it was previously visible
 			layoutService.setPartHidden(true, Parts.SIDEBAR_PART);
 		} else {
 			// If the current width is greater than the previous width, collapse the auxiliary bar back to the previous width (initial width)
-			layoutService.resizePart(Parts.AUXILIARYBAR_PART, (auxBarDimensions.width - _previousAuxiliaryBarWidth) * -1, 0);
+			layoutService.resizePart(Parts.AUXILIARYBAR_PART, (auxBarDimensions.width - ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth) * -1, 0);
 			// Restore the left side bar to the user's previous state
-			_previousSideBarVisibility ? layoutService.setPartHidden(false, Parts.SIDEBAR_PART) : layoutService.setPartHidden(true, Parts.SIDEBAR_PART);
+			ResizeAuxiliaryBarWidthAction._previousSideBarVisibility ? layoutService.setPartHidden(false, Parts.SIDEBAR_PART) : layoutService.setPartHidden(true, Parts.SIDEBAR_PART);
 			// Reset the previous width to null after collapsing
-			_previousAuxiliaryBarWidth = null;
+			ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth = null;
 		}
 
 		return Promise.resolve();


### PR DESCRIPTION
This PR addresses the issue `Shortcut to change chat size dynamically` #20 

I have added a ResizeAuxiliaryBarWidthAction in `auxiliaryBarActions.ts` for the chat bar (auxiliary bar) to expand it's size when pressed, and then revert to the smaller original size when pressed. The left side-bar is hidden when the chat bar is expanded, and is returned to its previous state upon the chat bar being reverted to its original size.

Primary Shortcut: The primary keyboard shortcut is `Ctrl (or Cmd on macOS) + [`.
Linux: On Linux, the primary shortcut is `CTRL + [`
macOS: On macOS, the primary shortcut is `CTRL + [`.
Windows: On Windows, the primary shortcut is `ALT + [`.

The max width of the chat bar is fixed at 70% the width of the App's inner window, the minimum width is 600px; the defaulted value is `2 * currentChatBarWidth`. The maximum width rule takes precedence over the minimum width rule. These sizes are arbitrary, but they look solid imo. Those preset values can be changed in the minWidth and maxWidth variables respectively.

Demo:
https://github.com/trypear/pearai-app/assets/13270623/937b0bba-bdc7-481b-b8d9-4a103ac480d5

