### PR TITLE
Implement new shortcut `Shift+Cmd+L` for opening chat

### DIFF
--- a/extensions/pearai-extension/lib/common/src/webview-api/OutgoingMessage.ts
+++ b/extensions/pearai-extension/lib/common/src/webview-api/OutgoingMessage.ts
@@ -6,6 +6,9 @@ export const outgoingMessageSchema = zod.discriminatedUnion("type", [
 		type: zod.literal("startChat"),
 	}),
 	zod.object({
+		type: zod.literal("openChat"),
+	}),
+	zod.object({
 		type: zod.literal("enterOpenAIApiKey"),
 	}),
 	zod.object({

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
@@ -79,7 +79,9 @@ export class ChatController {
 				break;
 			}
 			case "clickCollapsedConversation": {
-				const conversation = this.chatModel.getConversationById(message.data.id);
+				const conversation = this.chatModel.getConversationById(
+					message.data.id
+				);
 				if (conversation) {
 					this.chatModel.selectConversation(conversation);
 					await this.updateChatPanel();

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
@@ -50,11 +50,15 @@ export class ChatController {
 		await this.chatPanel.update(this.chatModel);
 	}
 
-	private async addAndShowConversation<T extends Conversation>(
+	/**
+	 * Opens and displays the specified conversation.
+	 * @param conversation The conversation to show.
+	 * @returns The specified conversation.
+	 */
+	private async showConversation<T extends Conversation>(
 		conversation: T
 	): Promise<T> {
-		this.chatModel.addAndSelectConversation(conversation);
-
+		await this.chatModel.selectConversation(conversation);
 		await this.showChatPanel();
 		await this.updateChatPanel();
 
@@ -75,8 +79,11 @@ export class ChatController {
 				break;
 			}
 			case "clickCollapsedConversation": {
-				this.chatModel.selectedConversationId = message.data.id;
-				await this.updateChatPanel();
+				const conversation = this.chatModel.getConversationById(message.data.id);
+				if (conversation) {
+					this.chatModel.selectConversation(conversation);
+					await this.updateChatPanel();
+				}
 				break;
 			}
 			case "sendMessage": {
@@ -87,6 +94,10 @@ export class ChatController {
 			}
 			case "startChat": {
 				await this.createConversation(this.basicChatTemplateId);
+				break;
+			}
+			case "openChat": {
+				await this.showLastSelectedConversation();
 				break;
 			}
 			case "deleteConversation": {
@@ -162,7 +173,8 @@ export class ChatController {
 				return;
 			}
 
-			await this.addAndShowConversation(result.conversation);
+			await this.chatModel.addAndSelectConversation(result.conversation);
+			await this.showConversation(result.conversation);
 
 			if (result.shouldImmediatelyAnswer) {
 				await result.conversation.answer();
@@ -172,5 +184,24 @@ export class ChatController {
 			console.log(error);
 			await vscode.window.showErrorMessage(error?.message ?? error);
 		}
+	}
+
+	/**
+	 * @returns The last selected conversation.
+	 */
+	private getLastSelectedConversation() {
+		return this.chatModel.getLastSelectedConversation();
+	}
+
+	/**
+	 * Opens and displays the last selected conversation.
+	 */
+	async showLastSelectedConversation() {
+		const lastSelectedConversation = this.getLastSelectedConversation();
+		if (!lastSelectedConversation) {
+			await this.createConversation("chat-en");
+			return;
+		}
+		await this.showConversation(lastSelectedConversation);
 	}
 }

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatController.ts
@@ -58,7 +58,7 @@ export class ChatController {
 	private async showConversation<T extends Conversation>(
 		conversation: T
 	): Promise<T> {
-		await this.chatModel.selectConversation(conversation);
+		this.chatModel.selectConversation(conversation);
 		await this.showChatPanel();
 		await this.updateChatPanel();
 
@@ -99,7 +99,7 @@ export class ChatController {
 				break;
 			}
 			case "openChat": {
-				await this.showLastSelectedConversation();
+				await this.showLastSelectedConversationOrCreateNew();
 				break;
 			}
 			case "deleteConversation": {
@@ -188,17 +188,15 @@ export class ChatController {
 		}
 	}
 
-	/**
-	 * @returns The last selected conversation.
-	 */
 	private getLastSelectedConversation() {
 		return this.chatModel.getLastSelectedConversation();
 	}
 
 	/**
-	 * Opens and displays the last selected conversation.
+	 * Opens and displays the last selected conversation, if one exists.
+	 * If there is no last selected conversation, creates a new one first.
 	 */
-	async showLastSelectedConversation() {
+	async showLastSelectedConversationOrCreateNew() {
 		const lastSelectedConversation = this.getLastSelectedConversation();
 		if (!lastSelectedConversation) {
 			await this.createConversation("chat-en");

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatModel.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatModel.ts
@@ -24,7 +24,7 @@ export class ChatModel {
 		if (!this.selectedConversationId) {
 			return;
 		}
-		return this.getConversationById(this.selectedConversationId)
+		return this.getConversationById(this.selectedConversationId);
 	}
 
 	deleteConversation(id: string) {

--- a/extensions/pearai-extension/lib/extension/src/chat/ChatModel.ts
+++ b/extensions/pearai-extension/lib/extension/src/chat/ChatModel.ts
@@ -4,13 +4,27 @@ export class ChatModel {
 	conversations: Array<Conversation> = [];
 	selectedConversationId: string | undefined;
 
+	selectConversation(conversation: Conversation) {
+		this.selectedConversationId = conversation.id;
+	}
+
 	addAndSelectConversation(conversation: Conversation) {
 		this.conversations.push(conversation);
-		this.selectedConversationId = conversation.id;
+		this.selectConversation(conversation);
 	}
 
 	getConversationById(id: string): Conversation | undefined {
 		return this.conversations.find((conversation) => conversation.id === id);
+	}
+
+	/**
+	 * @returns The last selected conversation, if it exists.
+	 */
+	getLastSelectedConversation(): Conversation | undefined {
+		if (!this.selectedConversationId) {
+			return;
+		}
+		return this.getConversationById(this.selectedConversationId)
 	}
 
 	deleteConversation(id: string) {

--- a/extensions/pearai-extension/lib/extension/src/extension.ts
+++ b/extensions/pearai-extension/lib/extension/src/extension.ts
@@ -97,6 +97,9 @@ export const activate = async (context: vscode.ExtensionContext) => {
 		vscode.commands.registerCommand("pearai.startChat", () => {
 			chatController.createConversation("chat-en");
 		}),
+		vscode.commands.registerCommand("pearai.openChat", () => {
+			chatController.showLastSelectedConversation();
+		}),
 		vscode.commands.registerCommand("pearai.editCode", () => {
 			chatController.createConversation("edit-code");
 		}),

--- a/extensions/pearai-extension/lib/extension/src/extension.ts
+++ b/extensions/pearai-extension/lib/extension/src/extension.ts
@@ -98,7 +98,7 @@ export const activate = async (context: vscode.ExtensionContext) => {
 			chatController.createConversation("chat-en");
 		}),
 		vscode.commands.registerCommand("pearai.openChat", () => {
-			chatController.showLastSelectedConversation();
+			chatController.showLastSelectedConversationOrCreateNew();
 		}),
 		vscode.commands.registerCommand("pearai.editCode", () => {
 			chatController.createConversation("edit-code");

--- a/extensions/pearai-extension/package.json
+++ b/extensions/pearai-extension/package.json
@@ -61,6 +61,11 @@
         "icon": "$(comment-discussion)"
       },
       {
+        "command": "pearai.openChat",
+        "title": "Open Chat",
+        "category": "PearAI"
+      },
+      {
         "command": "pearai.editCode",
         "title": "Edit Code 🖊️",
         "category": "PearAI",
@@ -243,10 +248,20 @@
       {
         "command": "pearai.startChat",
         "when": "isMac",
-        "key": "Cmd+l"
+        "key": "Shift+Cmd+l"
       },
       {
         "command": "pearai.startChat",
+        "when": "!isMac",
+        "key": "Shift+Alt+l"
+      },
+      {
+        "command": "pearai.openChat",
+        "when": "isMac",
+        "key": "Cmd+l"
+      },
+      {
+        "command": "pearai.openChat",
         "when": "!isMac",
         "key": "Alt+l"
       },


### PR DESCRIPTION
This PR implements https://github.com/trypear/pearai-app/issues/34.

The previous `Cmd+L` shortcut essentially did what @Fryingpannn wanted for the new `Shift+Cmd+L` command. I have not implemented the code selection feature. Let's raise a new issue for that and I or someone else can make a new PR. 

The following changes are implemented in this PR:
- If the chat is closed, `Cmd+L` opens the previously selected chat. If there is no previously selected chat, opens a new chat.
- If the chat is open, `Cmd+L` does nothing.
- If the chat is closed, `Shift+Cmd+L` starts and opens a new chat.
- If the chat is open, `Shift+Cmd+L` starts a new chat.
- New methods to help with selecting/showing the previous chat.
- Documentation for new methods.

https://github.com/trypear/pearai-app/assets/59787978/a5e51e9c-6d5b-4ddb-96df-eec99a83ba88

This is my first time contributing to a VSCode extension, critique and suggestions are welcome!
