### PR TITLE
make format on save work 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,17 +110,20 @@
 	"[plaintext]": {
 		"files.insertFinalNewline": false
 	},
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "always"
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
 	"[typescript]": {
-		"editor.defaultFormatter": "vscode.typescript-language-features",
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true
 	},
 	"[javascript]": {
 		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
-	},
-	"[rust]": {
-		"editor.defaultFormatter": "rust-lang.rust-analyzer",
-		"editor.formatOnSave": true,
 	},
 	"rust-analyzer.linkedProjects": [
 		"cli/Cargo.toml"


### PR DESCRIPTION
#62 is fixed for me at least. lmk if this doesn't fix for you after merge and we can continue to debug. some other things I did that might have helped make it work for me:
1. cmd+, to open settings --> search "format on save" --> editor: Format On Save ✅ (marked check box)
2. I have the extension Prettier - Code Formatter https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode which I think this uses. People might need to download this, so we can add to the getting started if it's needed. 

I also deleted the rust thing because I was getting a lint that the feature wasn't supported. 

btw, the lints in here are disgusting. I'll try to figure out how to fix more of them on save / get that experience better. 

Also, this PR defaults to VSCode PR -- we need to change that to Pear. I'll make an issue.



https://github.com/trypear/pearai-app/assets/19260511/47d1ba0f-e015-421d-bfe4-14d703d5cefb

