### PR TITLE
Add setup scripts for different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ product.overrides.json
 *.snap.actual
 .vscode-test
 extensions/pearai-submodule/
-extensions/pearai-extensions
-extensions/pearai-extension
+extensions/pearai-ref

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ product.overrides.json
 *.snap.actual
 .vscode-test
 extensions/pearai-submodule/
+extensions/pearai-extensions

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ product.overrides.json
 .vscode-test
 extensions/pearai-submodule/
 extensions/pearai-extensions
+extensions/pearai-extension

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,13 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
+			"label": "setup-environment",
+			"type": "shell",
+			"windows": { "command": "powershell ./scripts/pearai/setup-environment.ps1" },
+			"command": "./scripts/pearai/setup-environment.sh",
+			"problemMatcher": [] // Empty so users are not prompted to select progress reporting
+        },
+		{
 			"type": "npm",
 			"script": "watch-clientd",
 			"label": "Core - Build",

--- a/extensions/pearai-ref
+++ b/extensions/pearai-ref
@@ -1,1 +1,0 @@
-pearai-submodule/extensions/vscode

--- a/scripts/pearai/create-symlink.ps1
+++ b/scripts/pearai/create-symlink.ps1
@@ -1,5 +1,5 @@
 # Function to create the symbolic link
-function Create-Symlink {
+function Connect-Locations {
     param(
         [string]$targetPath,
         [string]$linkPath
@@ -14,4 +14,4 @@ $targetPath = $args[0]
 $linkPath = $args[1]
 
 # Call the function to create the symbolic link
-Create-Symlink -targetPath $targetPath -linkPath $linkPath
+Connect-Locations -targetPath $targetPath -linkPath $linkPath

--- a/scripts/pearai/create-symlink.ps1
+++ b/scripts/pearai/create-symlink.ps1
@@ -1,0 +1,17 @@
+# Function to create the symbolic link
+function Create-Symlink {
+    param(
+        [string]$targetPath,
+        [string]$linkPath
+    )
+
+    Write-Host "Creating symbolic link '$targetPath' -> '$linkPath'"
+    New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetPath
+}
+
+# Get the target and link paths from script parameters
+$targetPath = $args[0]
+$linkPath = $args[1]
+
+# Call the function to create the symbolic link
+Create-Symlink -targetPath $targetPath -linkPath $linkPath

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -1,0 +1,24 @@
+# Base functionality
+function Base-Functionality {
+    Write-Host "`nInitializing sub-modules..." -ForegroundColor White
+    git submodule update --init --recursive
+
+    Set-Location .\extensions\pearai-submodule
+
+    .\scripts\install-dependencies.ps1
+}
+
+# Setup all nessesary paths for this script
+$currentDir = Get-Location
+$targetPath = Join-Path -Path $currentDir -ChildPath '.\extensions\pearai-submodule\extensions\vscode'
+$linkPath = Join-Path -Path $currentDir -ChildPath '.\extensions\pearai-extension'
+$createLinkScript = Join-Path -Path $MyInvocation.MyCommand.Definition -ChildPath '.\create-symlink.ps1'
+
+# Check if the symbolic link exists
+if (-not (Test-Path $linkPath -PathType Any)) {
+    Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
+    Start-Process powershell.exe -Verb RunAs -ArgumentList ("-Command", "powershell.exe -File '$createLinkScript' '$targetPath' '$linkPath'")
+}
+
+# Run the base functionality
+Base-Functionality

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -6,13 +6,20 @@ function Base-Functionality {
     Set-Location .\extensions\pearai-submodule
 
     .\scripts\install-dependencies.ps1
+
+    Set-Location $currentDir
+
+    Write-Host "`nSetting up root application..." -ForegroundColor White
+    yarn install
+
+    .\scripts\code.bat
 }
 
 # Setup all nessesary paths for this script
 $currentDir = Get-Location
-$targetPath = Join-Path -Path $currentDir -ChildPath '.\extensions\pearai-submodule\extensions\vscode'
-$linkPath = Join-Path -Path $currentDir -ChildPath '.\extensions\pearai-extension'
-$createLinkScript = Join-Path -Path $MyInvocation.MyCommand.Definition -ChildPath '.\create-symlink.ps1'
+$targetPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-submodule\extensions\vscode'
+$linkPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-extension'
+$createLinkScript = Join-Path -Path (Get-Item $MyInvocation.MyCommand.Path).Directory -ChildPath 'create-symlink.ps1'
 
 # Check if the symbolic link exists
 if (-not (Test-Path $linkPath -PathType Any)) {

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -1,30 +1,52 @@
+# Function to execute a command and check its status
+function Invoke-CMD {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Command,
+        [Parameter(Mandatory=$true)]
+        [string]$ErrorMessage
+    )
+
+    & cmd /c $Command
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Setup | $ErrorMessage" -ForegroundColor Red
+        exit 1
+    }
+}
+
 # Base functionality
 function Initialize-BaseFunctionality {
     Write-Host "`nInitializing sub-modules..." -ForegroundColor White
-    git submodule update --init --recursive
+    Invoke-CMD -Command "git submodule update --init --recursive" -ErrorMessage "Failed to initialize git submodules"
 
     Set-Location .\extensions\pearai-submodule
 
-    .\scripts\install-dependencies.ps1
+    Invoke-CMD -Command "git fetch origin" -ErrorMessage "Failed to fetch latest changes from origin"
+    Invoke-CMD -Command "git pull origin main" -ErrorMessage "Failed to pull latest changes from origin/main"
+    Invoke-CMD -Command "git checkout main" -ErrorMessage "Failed to checkout main branch"
+
+	$script = Join-Path -Path $modulePath -ChildPath 'scripts\install-dependencies.ps1'
+    Invoke-CMD -Command "powershell.exe -File $script" -ErrorMessage "Failed to install dependencies for the submodule"
 
     Set-Location $currentDir
 
     Write-Host "`nSetting up root application..." -ForegroundColor White
-    yarn install
-
-    .\scripts\code.bat
+    Invoke-CMD -Command "yarn install" -ErrorMessage "Failed to install dependencies with yarn"
 }
 
-# Setup all nessesary paths for this script
+# Setup all necessary paths for this script
 $currentDir = Get-Location
-$targetPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-submodule\extensions\vscode'
-$linkPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-extension'
+$modulePath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-submodule'
+$targetPath = Join-Path -Path $modulePath -ChildPath 'extensions\vscode'
+$linkPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-ref'
 $createLinkScript = Join-Path -Path (Get-Item $MyInvocation.MyCommand.Path).Directory -ChildPath 'create-symlink.ps1'
 
 # Check if the symbolic link exists
+
 if (-not (Test-Path $linkPath -PathType Any)) {
     Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
     Start-Process powershell.exe -Verb RunAs -ArgumentList ("-Command", "powershell.exe -File '$createLinkScript' '$targetPath' '$linkPath'")
+	Start-Sleep 1
 }
 
 # Run the base functionality

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -1,5 +1,5 @@
 # Base functionality
-function Base-Functionality {
+function Initialize-BaseFunctionality {
     Write-Host "`nInitializing sub-modules..." -ForegroundColor White
     git submodule update --init --recursive
 
@@ -28,4 +28,4 @@ if (-not (Test-Path $linkPath -PathType Any)) {
 }
 
 # Run the base functionality
-Base-Functionality
+Initialize-BaseFunctionality

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -1,34 +1,47 @@
 #!/bin/bash
 
-# Base functionality
-function Base-Functionality {
-	echo -e "\nInitializing sub-modules..."
-	git submodule update --init --recursive
+# Function to execute a command and check its status
+execute() {
+	local cmd=$1
+	local failure_message=$2
 
-	cd ./extensions/pearai-submodule || exit
-
-	./scripts/install-dependencies.sh
-
-	cd $currentDir
-
-	echo -e "\nSetting up root application..."
-	yarn install
-
-	./scripts/code.sh
+	$cmd
+	if [ $? -ne 0 ]; then
+		echo "Setup | $failure_message"
+		exit 1
+	fi
 }
 
 # Setup all necessary paths for this script
-current_dir=$(pwd)
-target_path="$current_dir/extensions/pearai-submodule/extensions/vscode"
-link_path="$current_dir/extensions/pearai-extension"
+app_dir=$(pwd)
+target_path="$app_dir/extensions/pearai-submodule/extensions/vscode"
+link_path="$app_dir/extensions/pearai-ref"
 
 # Check if the symbolic link exists
 if [ ! -L "$link_path" ]; then
-	echo -e "\nCreating symbolic link 'extensions/pearai-submodule/extensions/vscode' -> 'extensions/pearai-extension'"
+	echo -e "\nCreating symbolic link 'extensions/pearai-submodule/extensions/vscode' -> 'extensions/pearai-ref'"
 
 	# Create the symbolic link
 	ln -s "$target_path" "$link_path"
 fi
 
 # Run the base functionality
-Base-Functionality
+echo -e "\nInitializing sub-modules..."
+execute "git submodule update --init --recursive" "Failed to initialize git submodules"
+
+execute "cd ./extensions/pearai-submodule" "Failed to change directory to extensions/pearai-submodule"
+
+execute "git fetch origin" "Failed to fetch latest changes from origin"
+
+execute "git pull origin main" "Failed to pull latest changes from origin/main"
+
+execute "git checkout main" "Failed to checkout main branch"
+
+execute "./scripts/install-dependencies.sh" "Failed to install dependencies for the submodule"
+
+execute "cd $app_dir" "Failed to change directory to application root"
+
+echo -e "\nSetting up root application..."
+pwd
+
+execute "yarn install" "Failed to install dependencies with yarn"

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Base functionality
+function Base-Functionality {
+    echo -e "\nInitializing sub-modules..."
+    git submodule update --init --recursive
+
+    cd ./extensions/pearai-submodule || exit
+
+    ./scripts/install-dependencies.sh
+}
+
+# Setup all necessary paths for this script
+current_dir=$(pwd)
+target_path="$current_dir/extensions/pearai-submodule/extensions/vscode"
+link_path="$current_dir/extensions/pearai-extension"
+
+# Check if the symbolic link exists
+if [ ! -L "$link_path" ]; then
+    echo -e "\nCreating symbolic link 'extensions/pearai-submodule/extensions/vscode' -> 'extensions/pearai-extension'"
+
+    # Create the symbolic link
+    ln -s "$target_path" "$link_path"
+fi
+
+# Run the base functionality
+Base-Functionality

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -2,12 +2,19 @@
 
 # Base functionality
 function Base-Functionality {
-    echo -e "\nInitializing sub-modules..."
-    git submodule update --init --recursive
+	echo -e "\nInitializing sub-modules..."
+	git submodule update --init --recursive
 
-    cd ./extensions/pearai-submodule || exit
+	cd ./extensions/pearai-submodule || exit
 
-    ./scripts/install-dependencies.sh
+	./scripts/install-dependencies.sh
+
+	cd $currentDir
+
+	echo -e "\nSetting up root application..."
+	yarn install
+
+	./scripts/code.sh
 }
 
 # Setup all necessary paths for this script
@@ -17,10 +24,10 @@ link_path="$current_dir/extensions/pearai-extension"
 
 # Check if the symbolic link exists
 if [ ! -L "$link_path" ]; then
-    echo -e "\nCreating symbolic link 'extensions/pearai-submodule/extensions/vscode' -> 'extensions/pearai-extension'"
+	echo -e "\nCreating symbolic link 'extensions/pearai-submodule/extensions/vscode' -> 'extensions/pearai-extension'"
 
-    # Create the symbolic link
-    ln -s "$target_path" "$link_path"
+	# Create the symbolic link
+	ln -s "$target_path" "$link_path"
 fi
 
 # Run the base functionality


### PR DESCRIPTION
- Adds a few scripts to support symlinking on windows/linux/macos.
- Added a task to VS Code to run the correct script based on environment
    -  Open `Command Palette` and type `Run Task` then select `setup-environment`
