### PR TITLE
Allow Pear to build on Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "extensions/pearai-submodule"]
 	path = extensions/pearai-submodule
 	url = https://github.com/trypear/pearai-extension.git
+	branch = main

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -26,7 +26,6 @@ set ELECTRON_ENABLE_STACK_DUMPING=1
 :: Get Pear AI
 setlocal
 cd extensions/pearai-submodule
-powershell.exe -executionpolicy bypass -file .\scripts\install-dependencies.ps1
 powershell.exe -executionpolicy bypass -file .\scripts\build-extension.ps1
 endlocal
 

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -25,9 +25,9 @@ set ELECTRON_ENABLE_STACK_DUMPING=1
 
 :: Get Pear AI
 setlocal
-cd extensions/pearai-extension
-call yarn install
-call yarn build-all
+cd extensions/pearai-submodule
+powershell.exe -executionpolicy bypass -file .\scripts\install-dependencies.ps1
+powershell.exe -executionpolicy bypass -file .\scripts\build-extension.ps1
 endlocal
 
 :: Launch Code


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR is intended for building Pear AI on Windows with the new submodule forked from Continue. Right now, this doesn't work as intended as the Webview does not load at all. But the extension can be built and added to the main app.

This will remain a draft until I figure out a way to get the Webview up and running again.