### PR TITLE
Make submodule folder be clean and have latest updates upon first cloning repo

### DIFF
--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -27,17 +27,31 @@ fi
 
 # Run the base functionality
 echo -e "\nInitializing sub-modules..."
+
+# Clone the submodule extension folder
 execute "git submodule update --init --recursive" "Failed to initialize git submodules"
 
 execute "cd ./extensions/pearai-submodule" "Failed to change directory to extensions/pearai-submodule"
 
-execute "git fetch origin" "Failed to fetch latest changes from origin"
+echo -e "\nSetting the submodule directory to match origin/main's latest changes..."
+# Set the current branch to match the latest origin/main branch for the submodule.
+execute "git reset origin/main" "Failed to git reset to origin/main"
 
-execute "git pull origin main" "Failed to pull latest changes from origin/main"
+# Discard any potential changes or merge conflicts in the working directory or staging area,
+# ensuring local branch matches remote branch exactly before checking out main
+execute "git reset --hard" "Failed to reset --hard"
 
 execute "git checkout main" "Failed to checkout main branch"
 
+execute "git fetch origin" "Failed to fetch latest changes from origin"
+
+# Make sure the submodule has the latest updates
+execute "git pull origin main" "Failed to pull latest changes from origin/main"
+
 execute "./scripts/install-dependencies.sh" "Failed to install dependencies for the submodule"
+
+# Discard the package.json and package-lock.json version update changes
+execute "git reset --hard" "Failed to reset --hard after submodule dependencies install"
 
 execute "cd $app_dir" "Failed to change directory to application root"
 


### PR DESCRIPTION
Before, when first cloning repo, would have merge conflicts when the scripts goes into submodule folder and tries to pull. This is because the submodule is initialized to a specific commit instead of main. What we can do is once this submodule initializes to a specific commit, we force it to checkout to main, and remove all directory and staged changes, to match with `origin/main`. Then the submodule would be the latest upon first install.

Tested by 
1. Removed everything in submodule `rm -rf extensions/pearai-submodule/{*,.*}`
2. Running `./scripts/pearai/setup-environment.sh` to setup

No merge conflicts, no additional changes. Submodule initialized with latest origin/main changes.