### PR TITLE
Added cargo/rust as a necessary tool in the CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ In order to download necessary tools, clone the repository, and install dependen
 
 You'll need the following tools:
 
+- [Rust/Cargo](https://www.rust-lang.org/tools/install)
 - [Git](https://git-scm.com)
 - [Node.JS](https://nodejs.org/en/), **x64**, version `=20.X.X`
 - [Yarn 1](https://classic.yarnpkg.com/en/), version `>=1.10.1 and <2`, follow the [installation guide](https://classic.yarnpkg.com/en/docs/install)


### PR DESCRIPTION
Added Rust (Cargo) to the necessary tools list in the Contributions document.

Issue #144

Many issues occur, making the submodule unusable without Cargo/Rust.

The project can start, even with errors, making the initial misconfiguration hard to spot.

This clarification should help prevent people from encountering the same issue.