### PR TITLE
fix: better handling for symlinks

### DIFF
--- a/scripts/pearai/create-symlink.ps1
+++ b/scripts/pearai/create-symlink.ps1
@@ -5,6 +5,13 @@ function Connect-Locations {
         [string]$linkPath
     )
 
+    if (Test-Path $linkPath -PathType Any) {
+        Write-Host "Removing existing Symbolic link at '$linkPath', before creating new one."
+        cmd /c rmdir /s /q $linkPath
+    }
+
+    Start-Sleep 1
+
     Write-Host "Creating symbolic link '$targetPath' -> '$linkPath'"
     New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetPath
 }

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -39,11 +39,9 @@ $createLinkScript = Join-Path -Path (Get-Item $MyInvocation.MyCommand.Path).Dire
 
 # Check if the symbolic link exists
 
-if (-not (Test-Path $linkPath -PathType Any)) {
-    Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
-    Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
-	Start-Sleep 1
-}
+Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
+Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
+Start-Sleep 1
 
 # Run the base functionality
 Initialize-BaseFunctionality

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+# Function to check the operating system
+check_os() {
+  case "$(uname -s)" in
+    Linux*)     os="Linux";;
+    Darwin*)    os="Mac";;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*) os="Windows";;
+    *)          os="Unknown";;
+  esac
+}
+
+check_os
+printf "\n\nDetected operating system: $os\n\n"
+
+# If the OS is Windows, give warning and prompt user to continue
+if [ "$os" == "Windows" ]; then
+  echo "This script is for unix systems (mac, linux)"
+	echo -e "Symbolic links might not work properly on Windows, please run windows scripts"
+	read -n 1 -s -r -p "Press any key to exit or enter to continue..."
+
+	# Check the user's input
+  if [ "$REPLY" != "" ]; then
+    echo -e "\n\e[91mExiting...\e[0m"
+    exit
+  fi
+fi
+
+
 # Function to execute a command and check its status
 execute() {
 	local cmd=$1
@@ -23,6 +50,8 @@ if [ ! -L "$link_path" ]; then
 	echo -e "\nCreating symbolic link '$link_path' -> '$target_path'"
 	# Create the symbolic link
 	ln -s "$target_path" "$link_path"
+else
+	echo -e "\n\e[93mSymbolic link already exists...\e[0m"
 fi
 
 # Run the base functionality


### PR DESCRIPTION
fixes #148 

symlinks sometimes fails on windows, (for example if ran .sh on windows accidently) or some other reasons.

on windows: check and remove already existing symlink, then create new one.
add conditions in bash script to check OS to prevent it from running on windows.

to test 
`.ps1` = create a normal folder with name `extensions/pearai-ref`, now run the script, it will remove the folder first and then create symlink
`.sh` script = run it on windows, it will give warning and prompt to continue or exit.