### PR TITLE
Better Symlinks fix

### DIFF
--- a/scripts/pearai/create-symlink.ps1
+++ b/scripts/pearai/create-symlink.ps1
@@ -4,6 +4,13 @@ function Connect-Locations {
         [string]$targetPath,
         [string]$linkPath
     )
+	    # Check if the symbolic link already exists and remove it if it does
+    if (Test-Path $linkPath -PathType SymbolicLink) {
+        Write-Host "Removing existing symbolic link at '$linkPath'..."
+        Remove-Item $linkPath
+    }
+	
+	Start-Sleep 1
 
     Write-Host "Creating symbolic link '$targetPath' -> '$linkPath'"
     New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetPath

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -37,13 +37,16 @@ $targetPath = Join-Path -Path $modulePath -ChildPath 'extensions\vscode'
 $linkPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-ref'
 $createLinkScript = Join-Path -Path (Get-Item $MyInvocation.MyCommand.Path).Directory -ChildPath 'create-symlink.ps1'
 
-# Check if the symbolic link exists
-
-if (-not (Test-Path $linkPath -PathType Any)) {
-    Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
-    Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
-	Start-Sleep 1
+# Check if the symbolic link exists and delete it if it does
+if (Test-Path $linkPath -PathType SymbolicLink) {
+    Write-Host "`nDeleting existing symbolic link '$linkPath'..." -ForegroundColor White
+    Remove-Item $linkPath
 }
+
+# Create new symbolic link
+Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
+Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
+Start-Sleep 1
 
 # Run the base functionality
 Initialize-BaseFunctionality

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -12,18 +12,31 @@ execute() {
 	fi
 }
 
+# Check if the current OS is Windows
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    echo "Setup | This script is intended for Mac/Linux and cannot be run on Windows."
+    exit 1
+fi
+
 # Setup all necessary paths for this script
 app_dir=$(pwd)
 target_path="$app_dir/extensions/pearai-submodule/extensions/vscode"
 link_path="$app_dir/extensions/pearai-ref"
 
-# Check if the symbolic link exists
-if [ ! -L "$link_path" ]; then
-	# Print message about creating a symbolic link from link_path to target_path
-	echo -e "\nCreating symbolic link '$link_path' -> '$target_path'"
-	# Create the symbolic link
-	ln -s "$target_path" "$link_path"
+# Check if the symbolic link exists and remove it if it does
+if [ -e "$link_path" ]; then
+    if [ -L "$link_path" ]; then
+        echo -e "\nRemoving existing symbolic link at '$link_path' before creating a new one."
+        rm "$link_path"
+    else
+        echo -e "\n'$link_path' already exists and is not a symbolic link. Removing it."
+        rm -rf "$link_path"
+    fi
 fi
+
+# Create new symbolic link
+echo -e "\nCreating symbolic link '$link_path' -> '$target_path'"
+ln -s "$target_path" "$link_path"
 
 # Run the base functionality
 echo -e "\nInitializing sub-modules..."


### PR DESCRIPTION
fix #148 
Changes Made:

ON WINDOWS:- 
Added logic to check and remove any existing symlink before creating a new one.
Extra Desc: Check and Remove Existing Symlink on Windows - On Windows, the script now checks if the target path is a symlink and removes it before creating a new one. This prevents issues where the symlink might be mistakenly converted to a regular folder.

OS Check Added:- Conditions in the Bash script to prevent execution on Windows.
Extra Desc: OS Detection and Prevention - Added a condition in the Bash script to detect the OS and prevent execution on Windows. This ensures that the script does not run on Windows, avoiding potential issues with symlinks.
