### PR TITLE
feat: set pearai extension location to secondary side bar (Auxiliary Bar)

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -801,7 +801,9 @@ registerAction2(class extends Action2 {
 	}
 
 	run(accessor: ServicesAccessor): void {
-		return accessor.get(IViewDescriptorService).reset();
+		accessor.get(IViewDescriptorService).reset();
+		const commandService = accessor.get(ICommandService);
+		commandService.executeCommand('workbench.action.movePearExtensionToAuxBar');
 	}
 });
 

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -417,6 +417,40 @@ class MoveViewsBetweenPanelsAction extends Action2 {
 	}
 }
 
+
+// Move Pear AI extension to secondary side bar (Auxiliary Bar) (we want secondary side bar to be default loaction for extension)
+class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
+    static readonly ID = 'workbench.action.movePearExtensionToAuxBar';
+		readonly PearExtensionId;
+
+    constructor() {
+        super(ViewContainerLocation.Sidebar, ViewContainerLocation.AuxiliaryBar, {
+            id: MovePearExtensionToAuxBarAction.ID,
+            title: localize2('movePearExtensionToAuxBar', "Move Pear Extension to Auxiliary Bar"),
+            category: Categories.View,
+            f1: true
+        });
+        this.PearExtensionId = 'workbench.view.extension.PearAI';
+    }
+
+    override run(accessor: ServicesAccessor): void {
+        const viewDescriptorService = accessor.get(IViewDescriptorService);
+        const layoutService = accessor.get(IWorkbenchLayoutService);
+        const viewsService = accessor.get(IViewsService);
+
+        const viewContainer = viewDescriptorService.getViewContainerById(this.PearExtensionId);
+				const destination = ViewContainerLocation.AuxiliaryBar;
+
+        if (viewContainer) {
+            viewDescriptorService.moveViewContainerToLocation(viewContainer, destination, undefined, this.desc.id);
+            layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+            viewsService.openViewContainer(viewContainer.id, true);
+        }
+    }
+}
+
+registerAction2(MovePearExtensionToAuxBarAction);
+
 // --- Move Panel Views To Secondary Side Bar
 
 class MovePanelToSidePanelAction extends MoveViewsBetweenPanelsAction {


### PR DESCRIPTION
#22 

VSCode API does not provide a way to set default location of extension to secondary side bar, this a workaround for it.

what this changes does :
- add a new vscode command to move pearai extension to auxialiary side bar.
- call this command from extension when it runs the very first time.
- call this command after user resets view from `reset views locations` command.
- this way, extension can still be moved around in views and we still set default location to secondary (unlike cursor editor, where its just fixed.)

how to test:
run command -> reset views locations (pearai extension should go to secondary bar)
