### PR TITLE
fix detached head after submodule init

### DIFF
--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -19,15 +19,36 @@ function Initialize-BaseFunctionality {
     Write-Host "`nInitializing sub-modules..." -ForegroundColor White
     Invoke-CMD -Command "git submodule update --init --recursive" -ErrorMessage "Failed to initialize git submodules"
 
+    Create-SymLink
+
     Set-Location .\extensions\pearai-submodule
+
+    # Checkout main - because submodule update leaves detached head.
+    Write-Host "`nSetting the submodule directory to match origin/main's latest changes..." -ForegroundColor White
+    Invoke-CMD -Command "git reset origin/main" -ErrorMessage "Failed to git reset to origin/main"
+    Invoke-CMD -Command "git reset --hard" -ErrorMessage "Failed to reset --hard"
+    Write-Host "`nChecking out the 'main' branch in submodule..." -ForegroundColor White
+    Invoke-CMD -Command "git checkout main" -ErrorMessage "Failed to checkout the 'main' branch in the submodule"
+    Invoke-CMD -Command "git fetch origin" -ErrorMessage "Failed to fetch latest changes from origin"
+    Invoke-CMD -Command "git pull origin main" -ErrorMessage "Failed to pull latest changes from origin/main"
+
 
 	$script = Join-Path -Path $modulePath -ChildPath 'scripts\install-dependencies.ps1'
     Invoke-CMD -Command "powershell.exe -ExecutionPolicy Bypass -File $script" -ErrorMessage "Failed to install dependencies for the submodule"
+
+    # Discard the package.json and package-lock.json version update changes     
+    Invoke-CMD -Command "git reset --hard" -ErrorMessage "Failed to reset --hard after submodule dependencies install"
 
     Set-Location $currentDir
 
     Write-Host "`nSetting up root application..." -ForegroundColor White
     Invoke-CMD -Command "yarn install" -ErrorMessage "Failed to install dependencies with yarn"
+}
+
+function Create-SymLink {
+    Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
+    Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
+    Start-Sleep 1
 }
 
 # Setup all necessary paths for this script
@@ -36,12 +57,6 @@ $modulePath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-submodul
 $targetPath = Join-Path -Path $modulePath -ChildPath 'extensions\vscode'
 $linkPath = Join-Path -Path $currentDir -ChildPath 'extensions\pearai-ref'
 $createLinkScript = Join-Path -Path (Get-Item $MyInvocation.MyCommand.Path).Directory -ChildPath 'create-symlink.ps1'
-
-# Check if the symbolic link exists
-
-Write-Host "`nCreating symbolic link 'extensions\pearai-submodule\extensions\vscode' -> 'extensions\pearai-extension'" -ForegroundColor White
-Start-Process powershell.exe -Verb RunAs -ArgumentList ("-ExecutionPolicy Bypass ", "-Command", "powershell.exe -ExecutionPolicy Bypass -File '$createLinkScript' '$targetPath' '$linkPath'")
-Start-Sleep 1
 
 # Run the base functionality
 Initialize-BaseFunctionality

--- a/scripts/pearai/setup-environment.sh
+++ b/scripts/pearai/setup-environment.sh
@@ -44,6 +44,12 @@ app_dir=$(pwd)
 target_path="$app_dir/extensions/pearai-submodule/extensions/vscode"
 link_path="$app_dir/extensions/pearai-ref"
 
+# Run the base functionality
+echo -e "\nInitializing sub-modules..."
+# Clone the submodule extension folder
+execute "git submodule update --init --recursive" "Failed to initialize git submodules"
+
+
 # Check if the symbolic link exists
 if [ ! -L "$link_path" ]; then
 	# Print message about creating a symbolic link from link_path to target_path
@@ -54,11 +60,6 @@ else
 	echo -e "\n\e[93mSymbolic link already exists...\e[0m"
 fi
 
-# Run the base functionality
-echo -e "\nInitializing sub-modules..."
-
-# Clone the submodule extension folder
-execute "git submodule update --init --recursive" "Failed to initialize git submodules"
 
 execute "cd ./extensions/pearai-submodule" "Failed to change directory to extensions/pearai-submodule"
 


### PR DESCRIPTION
improve for windows script - `setup_environment.ps1`

changes - 
- `git submodule update` leaves a detached HEAD, fix that. (`.sh` scripts already have it)
- change order of symbolic link creation. - [context discord message](https://discord.com/channels/1237009981803462729/1249121705419608205/1258075352274702416) by @MaySoMusician

submodule update leaves detached head in submodule directory, and then proceeds the rest of the script with that detached head, we don't install node modules from latest changes, we need to check out to main branch and pull latest changes and run the script on main branch. mac script already does this, this pr adds it for windows scripts too.

the very first run of scripts, right after cloning repo, symlink creation fails silently because submodule directory is empty and is initialized after it.