### PR TITLE
Clarified Walkthrough label

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -170,7 +170,7 @@ const Button = (title: string, href: string) => `[${title}](${href})`;
 export const walkthroughs: GettingStartedWalkthroughContent = [
 	{
 		id: 'Setup',
-		title: localize('gettingStarted.setup.title', "Get Started with Pear AI"),
+		title: localize('gettingStarted.setup.title', "Get Started with the PearAI editor"),
 		description: localize('gettingStarted.setup.description', "Customize your editor, learn the basics, and start coding"),
 		isFeatured: true,
 		icon: setupIcon,


### PR DESCRIPTION
## Description
Changed the PearAI walkthrough label to stop confusion between editor and AI settings.

Related to https://github.com/trypear/pearai-submodule/pull/102 in the submodule
