### PR TITLE
fix: #262 prioritize pearai commands

### DIFF
--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -179,7 +179,7 @@ export class KeybindingResolver {
     	return result.sort((a, b) => {
 			const priorityA = a.isDefault ? (a.extensionId === 'pearai.pearai' ? 2 : 1) : 3;
 			const priorityB = b.isDefault ? (b.extensionId === 'pearai.pearai' ? 2 : 1) : 3;
-			return priorityB - priorityA;
+			return priorityA - priorityB;
 		});
 	}
 
@@ -223,7 +223,7 @@ export class KeybindingResolver {
 		}
 
 		conflicts.push(item);
-		conflicts.sort((a, b) => this._getKeybindingPriority(b) - this._getKeybindingPriority(a));
+		conflicts.sort((a, b) => this._getKeybindingPriority(a) - this._getKeybindingPriority(b));
 		this._map.set(keypress, conflicts);
 		this._addToLookupMap(item);
 	}
@@ -385,28 +385,18 @@ export class KeybindingResolver {
 	}
 
 	private _findCommand(context: IContext, matches: ResolvedKeybindingItem[]): ResolvedKeybindingItem | null {
-		// matches are already sorted by priority due to _addKeyPress
-		for (const k of matches) {
-			if (KeybindingResolver._contextMatchesRules(context, k.when)) {
-				return k;
+		for (let i = matches.length - 1; i >= 0; i--) {
+			const k = matches[i];
+
+			if (!KeybindingResolver._contextMatchesRules(context, k.when)) {
+				continue;
 			}
+
+			return k;
 		}
+
 		return null;
 	}
-
-	// private _findCommand(context: IContext, matches: ResolvedKeybindingItem[]): ResolvedKeybindingItem | null {
-	// 	for (let i = matches.length - 1; i >= 0; i--) {
-	// 		const k = matches[i];
-
-	// 		if (!KeybindingResolver._contextMatchesRules(context, k.when)) {
-	// 			continue;
-	// 		}
-
-	// 		return k;
-	// 	}
-
-	// 	return null;
-	// }
 
 	private static _contextMatchesRules(context: IContext, rules: ContextKeyExpression | null | undefined): boolean {
 		if (!rules) {

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -88,6 +88,17 @@ export class KeybindingResolver {
 		}
 	}
 
+	private _getKeybindingPriority(item: ResolvedKeybindingItem): number {
+		if (!item.isDefault) {
+			return 3; // User keybindings (highest priority)
+		}
+		if (item.extensionId === 'pearai.pearai') {
+			// todo: remove id hardcode and extract extension id from env or settings
+			return 2; // Pear AI keybindings
+		}
+		return 1; // Other extensions' keybindings
+	}
+
 	private static _isTargetedForRemoval(defaultKb: ResolvedKeybindingItem, keypress: string[] | null, when: ContextKeyExpression | undefined): boolean {
 		if (keypress) {
 			for (let i = 0; i < keypress.length; i++) {
@@ -164,7 +175,12 @@ export class KeybindingResolver {
 				continue;
 			}
 		}
-		return result;
+		// Sort the result array based on priority before returning
+    	return result.sort((a, b) => {
+			const priorityA = a.isDefault ? (a.extensionId === 'pearai.pearai' ? 2 : 1) : 3;
+			const priorityB = b.isDefault ? (b.extensionId === 'pearai.pearai' ? 2 : 1) : 3;
+			return priorityB - priorityA;
+		});
 	}
 
 	private _addKeyPress(keypress: string, item: ResolvedKeybindingItem): void {
@@ -207,6 +223,8 @@ export class KeybindingResolver {
 		}
 
 		conflicts.push(item);
+		conflicts.sort((a, b) => this._getKeybindingPriority(b) - this._getKeybindingPriority(a));
+		this._map.set(keypress, conflicts);
 		this._addToLookupMap(item);
 	}
 
@@ -367,18 +385,28 @@ export class KeybindingResolver {
 	}
 
 	private _findCommand(context: IContext, matches: ResolvedKeybindingItem[]): ResolvedKeybindingItem | null {
-		for (let i = matches.length - 1; i >= 0; i--) {
-			const k = matches[i];
-
-			if (!KeybindingResolver._contextMatchesRules(context, k.when)) {
-				continue;
+		// matches are already sorted by priority due to _addKeyPress
+		for (const k of matches) {
+			if (KeybindingResolver._contextMatchesRules(context, k.when)) {
+				return k;
 			}
-
-			return k;
 		}
-
 		return null;
 	}
+
+	// private _findCommand(context: IContext, matches: ResolvedKeybindingItem[]): ResolvedKeybindingItem | null {
+	// 	for (let i = matches.length - 1; i >= 0; i--) {
+	// 		const k = matches[i];
+
+	// 		if (!KeybindingResolver._contextMatchesRules(context, k.when)) {
+	// 			continue;
+	// 		}
+
+	// 		return k;
+	// 	}
+
+	// 	return null;
+	// }
 
 	private static _contextMatchesRules(context: IContext, rules: ContextKeyExpression | null | undefined): boolean {
 		if (!rules) {

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -732,7 +732,7 @@ registerAction2(class ToggleInlineCoverage extends Action2 {
 			category: Categories.Test,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyI),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyI),
 			},
 			icon: testingCoverageReport,
 			menu: [

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -644,7 +644,7 @@ export class RunAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingRunAllIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Run,
@@ -662,7 +662,7 @@ export class DebugAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingDebugIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Debug,
@@ -680,7 +680,7 @@ export class CoverageAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingCoverageIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Coverage,
@@ -697,7 +697,7 @@ export class CancelTestRunAction extends Action2 {
 			icon: icons.testingCancelIcon,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyX),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyX),
 			},
 			menu: {
 				id: MenuId.ViewTitle,
@@ -855,7 +855,7 @@ export class ShowMostRecentOutputAction extends Action2 {
 			icon: Codicon.terminal,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyO),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyO),
 			},
 			precondition: TestingContextKeys.hasAnyResults.isEqualTo(true),
 			menu: [{
@@ -1074,7 +1074,7 @@ export class RunAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Run);
 	}
@@ -1089,7 +1089,7 @@ export class DebugAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Debug);
 	}
@@ -1104,7 +1104,7 @@ export class CoverageAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Coverage);
 	}
@@ -1248,7 +1248,7 @@ export class RunCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Run);
 	}
@@ -1263,7 +1263,7 @@ export class DebugCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Debug);
 	}
@@ -1278,7 +1278,7 @@ export class CoverageCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Coverage);
 	}
@@ -1385,7 +1385,7 @@ export class ReRunFailedTests extends RunOrDebugFailedTests {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyCode.KeyE),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyE),
 			},
 		});
 	}
@@ -1406,7 +1406,7 @@ export class DebugFailedTests extends RunOrDebugFailedTests {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyE),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyE),
 			},
 		});
 	}
@@ -1427,7 +1427,7 @@ export class ReRunLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyL),
 			},
 		});
 	}
@@ -1448,7 +1448,7 @@ export class DebugLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyL),
 			},
 		});
 	}
@@ -1469,7 +1469,7 @@ export class CoverageLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL),
 			},
 		});
 	}
@@ -1506,7 +1506,7 @@ export class OpenOutputPeek extends Action2 {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyM),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyM),
 			},
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1528,7 +1528,7 @@ export class ToggleInlineTestOutput extends Action2 {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyI),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyI),
 			},
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1578,7 +1578,7 @@ export class RefreshTestsAction extends Action2 {
 			icon: icons.testingRefreshTests,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyR),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyR),
 				when: TestingContextKeys.canRefreshTests.isEqualTo(true),
 			},
 			menu: refreshMenus(false),

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -644,7 +644,7 @@ export class RunAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingRunAllIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Run,
@@ -662,7 +662,7 @@ export class DebugAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingDebugIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Debug,
@@ -680,7 +680,7 @@ export class CoverageAllAction extends RunOrDebugAllTestsAction {
 				icon: icons.testingCoverageIcon,
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
-					primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA),
+					primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyA),
 				},
 			},
 			TestRunProfileBitset.Coverage,
@@ -697,7 +697,7 @@ export class CancelTestRunAction extends Action2 {
 			icon: icons.testingCancelIcon,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyX),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyX),
 			},
 			menu: {
 				id: MenuId.ViewTitle,
@@ -855,7 +855,7 @@ export class ShowMostRecentOutputAction extends Action2 {
 			icon: Codicon.terminal,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyO),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyO),
 			},
 			precondition: TestingContextKeys.hasAnyResults.isEqualTo(true),
 			menu: [{
@@ -1074,7 +1074,7 @@ export class RunAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Run);
 	}
@@ -1089,7 +1089,7 @@ export class DebugAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Debug);
 	}
@@ -1104,7 +1104,7 @@ export class CoverageAtCursor extends ExecuteTestAtCursor {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyC),
 			},
 		}, TestRunProfileBitset.Coverage);
 	}
@@ -1248,7 +1248,7 @@ export class RunCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Run);
 	}
@@ -1263,7 +1263,7 @@ export class DebugCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Debug);
 	}
@@ -1278,7 +1278,7 @@ export class CoverageCurrentFile extends ExecuteTestsInCurrentFile {
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF),
 			},
 		}, TestRunProfileBitset.Coverage);
 	}
@@ -1385,7 +1385,7 @@ export class ReRunFailedTests extends RunOrDebugFailedTests {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyE),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyCode.KeyE),
 			},
 		});
 	}
@@ -1406,7 +1406,7 @@ export class DebugFailedTests extends RunOrDebugFailedTests {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyE),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyE),
 			},
 		});
 	}
@@ -1427,7 +1427,7 @@ export class ReRunLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyCode.KeyL),
 			},
 		});
 	}
@@ -1448,7 +1448,7 @@ export class DebugLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyL),
 			},
 		});
 	}
@@ -1469,7 +1469,7 @@ export class CoverageLastRun extends RunOrDebugLastRun {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL),
 			},
 		});
 	}
@@ -1506,7 +1506,7 @@ export class OpenOutputPeek extends Action2 {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyM),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyM),
 			},
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1528,7 +1528,7 @@ export class ToggleInlineTestOutput extends Action2 {
 			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyI),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyI),
 			},
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1578,7 +1578,7 @@ export class RefreshTestsAction extends Action2 {
 			icon: icons.testingRefreshTests,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyR),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit2, KeyMod.CtrlCmd | KeyCode.KeyR),
 				when: TestingContextKeys.canRefreshTests.isEqualTo(true),
 			},
 			menu: refreshMenus(false),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Description ✏️

Closes #262
what changed:
Prioritizes our keybindings in the resolver. The priority of keybindings is as follows:
1) user keybinding
2) pearai.pearai keybindings
3) other extensions' keybindings

Other changes:
- keybindings for test suite changed from `cmd+;` `to cmd+shift+2` to eliminate conflict with the auxiliary side bar command

- ## Checklist ✅

- [x] The base branch of this PR is `preview`, rather than `main`
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).