### PR TITLE
Shortcut change to resize chat  on the app side

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -163,15 +163,15 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.BracketLeft,
+				primary: KeyMod.CtrlCmd | KeyCode.Backslash,
 				linux: {
-					primary: KeyMod.CtrlCmd | KeyCode.BracketLeft
+					primary: KeyMod.CtrlCmd | KeyCode.Backslash
 				},
 				win: {
-					primary: KeyMod.Alt | KeyCode.BracketLeft
+					primary: KeyMod.CtrlCmd | KeyCode.Backslash
 				},
 				mac: {
-					primary: KeyMod.CtrlCmd | KeyCode.BracketLeft
+					primary: KeyMod.CtrlCmd | KeyCode.Backslash
 				}
 			},
 		});
@@ -205,6 +205,7 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 		// Calculate the minimum width for the auxiliary bar
 		// 70% of the window width is the maximum width
 		const maxWidth = (0.7 * mainWindow.innerWidth);
+		console.log('maxWidth', maxWidth);
 		// The minimum width is the maximum width, unless it is less than the max of (previous width * 2) or the predetermined minimum width
 		const minWidth = Math.min(maxWidth, Math.max(ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth * 2, PSEUDO_MINIMUM_AUX_BAR_WIDTH));
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -205,7 +205,6 @@ export class ResizeAuxiliaryBarWidthAction extends Action2 {
 		// Calculate the minimum width for the auxiliary bar
 		// 70% of the window width is the maximum width
 		const maxWidth = (0.7 * mainWindow.innerWidth);
-		console.log('maxWidth', maxWidth);
 		// The minimum width is the maximum width, unless it is less than the max of (previous width * 2) or the predetermined minimum width
 		const minWidth = Math.min(maxWidth, Math.max(ResizeAuxiliaryBarWidthAction._previousAuxiliaryBarWidth * 2, PSEUDO_MINIMUM_AUX_BAR_WIDTH));
 

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -73,17 +73,27 @@ abstract class AbstractSplitEditorAction extends Action2 {
 export class SplitEditorAction extends AbstractSplitEditorAction {
 
 	static readonly ID = SPLIT_EDITOR;
+	static readonly LABEL = localize2('splitEditor', 'Split Editor');
 
 	constructor() {
 		super({
 			id: SplitEditorAction.ID,
-			title: localize2('splitEditor', 'Split Editor'),
+			title: SplitEditorAction.LABEL,
+			category: Categories.View,
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.Backslash
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Backslash,
+				linux: {
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Backslash
+				},
+				win: {
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Backslash
+				},
+				mac: {
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Backslash
+				}
 			},
-			category: Categories.View
 		});
 	}
 }


### PR DESCRIPTION
Description ✏️
Closes #277 

What changed? Feel free to be brief.

Bullet points are helpful.

Screenshots are helpful (if applicable).

Updated the keybindings to make the chat bigger on the auxiliaryBarActions file
