### PR TITLE
Remove note from license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,8 @@
-   Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-NOTE FROM FOUNDERS: THIS USED TO BE A CHATGPT RECOMMENDED AND GENERATED EE LICENSE. WE ARE OPEN SOURCED. THE LICENSE HAS BEEN HERE SINCE THE BEGINNING: https://github.com/trypear/pearai-submodule/blob/main/LICENSE
 
    1. Definitions.
 


### PR DESCRIPTION
Replaces license with the stock Apache 2.0 license