### PR TITLE
"Visual Studio Code" → "PearAI" in theme notification prompt

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -574,7 +574,7 @@ registerAction2(class extends Action2 {
 	}
 });
 
-CommandsRegistry.registerCommand('workbench.action.previewColorTheme', async function (accessor: ServicesAccessor, extension: { publisher: string; name: string; version: string }, themeSettingsId?: string) {
+CommandsRegistry.registerCommand('workbench.action.previewColorTheme', async function(accessor: ServicesAccessor, extension: { publisher: string; name: string; version: string }, themeSettingsId?: string) {
 	const themeService = accessor.get(IWorkbenchThemeService);
 
 	let themes = findBuiltInThemes(await themeService.getColorThemes(), extension);
@@ -920,7 +920,7 @@ class DefaultThemeUpdatedNotificationContribution implements IWorkbenchContribut
 			];
 			await this._notificationService.prompt(
 				Severity.Info,
-				localize({ key: 'themeUpdatedNotification', comment: ['{0} is the name of the new default theme'] }, "Visual Studio Code now ships with a new default theme '{0}'. If you prefer, you can switch back to the old theme or try one of the many other color themes available.", newTheme.label),
+				localize({ key: 'themeUpdatedNotification', comment: ['{0} is the name of the new default theme'] }, "PearAI now ships with a new default theme '{0}'. If you prefer, you can switch back to the old theme or try one of the many other color themes available.", newTheme.label),
 				choices,
 				{
 					onCancel: () => this._writeTelemetry('cancel')
@@ -948,7 +948,7 @@ class DefaultThemeUpdatedNotificationContribution implements IWorkbenchContribut
 			}];
 			await this._notificationService.prompt(
 				Severity.Info,
-				localize({ key: 'newThemeNotification', comment: ['{0} is the name of the new default theme'] }, "Visual Studio Code now ships with a new default theme '{0}'. Do you want to give it a try?", theme.label),
+				localize({ key: 'newThemeNotification', comment: ['{0} is the name of the new default theme'] }, "PearAI now ships with a new default theme '{0}'. Do you want to give it a try?", theme.label),
 				choices,
 				{ onCancel: () => this._writeTelemetry('cancel') }
 			);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixed theme notification prompt to match PearAI name

Before:
<img width="528" alt="Screenshot 2024-11-12 at 5 36 47 AM" src="https://github.com/user-attachments/assets/4ac6ba4d-d7eb-4753-8f10-365d9b80dd94">

