### PR TITLE
fix editor focus when close overlay

### DIFF
--- a/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
+++ b/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
@@ -19,6 +19,7 @@ import {
 import { WebviewService } from "vs/workbench/contrib/webview/browser/webviewService";
 import { URI } from "vs/base/common/uri";
 import { ExtensionIdentifier } from "vs/platform/extensions/common/extensions";
+import { IEditorGroupsService } from "vs/workbench/services/editor/common/editorGroupsService";
 
 const PEAROVERLAY_ID = "pearai.pearAIChatView";
 const PEAR_OVERLAY_TITLE = "pearai.pearOverlay";
@@ -47,6 +48,8 @@ export class PearOverlayPart extends Part {
 		private readonly _webviewViewService: IWebviewViewService,
 		@IInstantiationService
 		private readonly _instantiationService: IInstantiationService,
+		@IEditorGroupsService
+		private readonly _editorGroupsService: IEditorGroupsService,
 	) {
 		super(
 			PearOverlayPart.ID,
@@ -237,6 +240,9 @@ export class PearOverlayPart extends Part {
 		setTimeout(() => {
 			this.fullScreenOverlay!.style.zIndex = "-10";
 			container.style.display = "none";
+
+			// Focus the active editor
+			this._editorGroupsService.activeGroup.focus();
 		}, 20); // 20ms matches the animation duration
 	}
 

--- a/src/vs/workbench/browser/parts/overlay/pearOverlayService.ts
+++ b/src/vs/workbench/browser/parts/overlay/pearOverlayService.ts
@@ -100,22 +100,22 @@ export class PearOverlayService
 
 	private registerCommands(): void {
 		// Register commands for external use e.g. in pearai submodule
-		CommandsRegistry.registerCommand('pearai.isOverlayVisible', (accessor) => {
+		CommandsRegistry.registerCommand("pearai.isOverlayVisible", (accessor) => {
 			const overlayService = accessor.get(IPearOverlayService);
 			return overlayService.isVisible();
 		});
 
-		CommandsRegistry.registerCommand('pearai.showOverlay', (accessor) => {
+		CommandsRegistry.registerCommand("pearai.showOverlay", (accessor) => {
 			const overlayService = accessor.get(IPearOverlayService);
 			overlayService.show();
 		});
 
-		CommandsRegistry.registerCommand('pearai.hideOverlay', (accessor) => {
+		CommandsRegistry.registerCommand("pearai.hideOverlay", (accessor) => {
 			const overlayService = accessor.get(IPearOverlayService);
 			overlayService.hide();
 		});
 
-		CommandsRegistry.registerCommand('pearai.toggleOverlay', (accessor) => {
+		CommandsRegistry.registerCommand("pearai.toggleOverlay", (accessor) => {
 			const overlayService = accessor.get(IPearOverlayService);
 			overlayService.toggle();
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes editor focus issue by focusing the active editor after closing the overlay in `pearOverlayPart.ts`.
> 
>   - **Behavior**:
>     - In `pearOverlayPart.ts`, after closing the overlay, the active editor is focused using `this._editorGroupsService.activeGroup.focus()`.
>   - **Commands**:
>     - In `pearOverlayService.ts`, command strings are changed from single to double quotes for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 010d0a67fb581e006948289765bf816d9435b44d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->