### PR TITLE
disable welcome page

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -33,7 +33,7 @@ export const restoreWalkthroughsConfigurationKey = 'workbench.welcomePage.restor
 export type RestoreWalkthroughsConfigurationValue = { folder: string; category?: string; step?: string };
 
 const configurationKey = 'workbench.startupEditor';
-const oldConfigurationKey = 'workbench.welcome.enabled';
+// const oldConfigurationKey = 'workbench.welcome.enabled';
 const telemetryOptOutStorageKey = 'workbench.telemetryOptOutShown';
 
 export class StartupPageEditorResolverContribution implements IWorkbenchContribution {
@@ -97,7 +97,12 @@ export class StartupPageRunnerContribution implements IWorkbenchContribution {
 		// Wait for resolving startup editor until we are restored to reduce startup pressure
 		await this.lifecycleService.when(LifecyclePhase.Restored);
 
-		// Always open Welcome page for first-launch, no matter what is open or which startupEditor is set.
+		// Skip welcome page if startup editor is set to 'none'
+		if (this.configurationService.getValue(configurationKey) === 'none') {
+			return;
+		}
+
+		// Show telemetry opt-out notice on first launch unless startup editor is explicitly set to 'none'
 		if (
 			this.productService.enableTelemetry
 			&& this.productService.showTelemetryOptOut
@@ -220,11 +225,9 @@ function isStartupPageEnabled(configurationService: IConfigurationService, conte
 	}
 
 	const startupEditor = configurationService.inspect<string>(configurationKey);
-	if (!startupEditor.userValue && !startupEditor.workspaceValue) {
-		const welcomeEnabled = configurationService.inspect(oldConfigurationKey);
-		if (welcomeEnabled.value !== undefined && welcomeEnabled.value !== null) {
-			return welcomeEnabled.value;
-		}
+
+	if (startupEditor.value === 'none') {
+		return false;
 	}
 
 	return startupEditor.value === 'welcomePage'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable welcome page if `workbench.startupEditor` is set to 'none' in `startupPage.ts`.
> 
>   - **Behavior**:
>     - Skip welcome page if `workbench.startupEditor` is set to 'none' in `StartupPageRunnerContribution.run()`.
>     - Comment out `oldConfigurationKey` in `startupPage.ts`, indicating deprecation.
>   - **Functions**:
>     - Modify `isStartupPageEnabled()` to return false if `startupEditor.value` is 'none'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 815c05ea2507bd889ea897bcd0a0004084f19802. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->