### PR TITLE
Update gulpfile.vscode.linux.js

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -267,7 +267,7 @@ function prepareSnapPackage(arch) {
 			.pipe(rename(function (p) { p.dirname = `usr/share/${product.applicationName}/${p.dirname}`; }));
 
 		const snapcraft = gulp.src('resources/linux/snap/snapcraft.yaml', { base: '.' })
-			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(replace('@@NAME@@', product.applicationName.toLowerCase()))
 			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
 			// Possible run-on values https://snapcraft.io/docs/architectures
 			.pipe(replace('@@ARCHITECTURE@@', arch === 'x64' ? 'amd64' : arch))


### PR DESCRIPTION
Added .toLowerCase() in the snapcraft function due the unsupported of capital letters in snap store utility.
The name of PearAI must be lowercase.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
