### PR TITLE
Update shellIntegration-bash.sh

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -10,6 +10,9 @@ fi
 
 VSCODE_SHELL_INTEGRATION=1
 
+# Check if the system is NixOS if yes unset this var for fixing the error "Segmentation fault (core dumped)"
+[ -f /etc/NIXOS ] && unset LD_LIBRARY_PATH
+
 # Run relevant rc/profile only if shell integration has been injected, not when run manually
 if [ "$VSCODE_INJECTION" == "1" ]; then
 	if [ -z "$VSCODE_SHELL_LOGIN" ]; then


### PR DESCRIPTION
Check if the system is NixOS if yes unset this var for fixing the error "Segmentation fault (core dumped)" 

[ -f /etc/NIXOS ] && unset LD_LIBRARY_PATH

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add check for NixOS in `shellIntegration-bash.sh` to unset `LD_LIBRARY_PATH` and prevent segmentation faults.
> 
>   - **Behavior**:
>     - In `shellIntegration-bash.sh`, check for NixOS by verifying the existence of `/etc/NIXOS`.
>     - If NixOS is detected, unset `LD_LIBRARY_PATH` to prevent segmentation fault errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 189af751d9f4c4d7d6c0f208abb9cf1186c52564. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->