### PR TITLE
auxiliary bar contibution point

### DIFF
--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -70,6 +70,11 @@ export const viewsContainersContribution: IJSONSchema = {
 			description: localize('views.container.panel', "Contribute views containers to Panel"),
 			type: 'array',
 			items: viewsContainerSchema
+		},
+		"auxiliarybar": {
+			description: localize('views.container.auxiliarybar', "Contribute views containers to Secondary Side Bar"),
+			type: 'array',
+			items: viewsContainerSchema
 		}
 	}
 };
@@ -300,6 +305,8 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 		const viewContainersRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
 		let activityBarOrder = CUSTOM_VIEWS_START_ORDER + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.Sidebar).length;
 		let panelOrder = 5 + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.Panel).length + 1;
+		let auxiliaryBarOrder = CUSTOM_VIEWS_START_ORDER + viewContainersRegistry.all.filter(v => !!v.extensionId && viewContainersRegistry.getViewContainerLocation(v) === ViewContainerLocation.AuxiliaryBar).length;
+
 		for (const { value, collector, description } of extensionPoints) {
 			Object.entries(value).forEach(([key, value]) => {
 				if (!this.isValidViewsContainer(value, collector)) {
@@ -311,6 +318,9 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 						break;
 					case 'panel':
 						panelOrder = this.registerCustomViewContainers(value, description, panelOrder, existingViewContainers, ViewContainerLocation.Panel);
+						break;
+					case 'auxiliarybar':
+						auxiliaryBarOrder = this.registerCustomViewContainers(value, description, auxiliaryBarOrder, existingViewContainers, ViewContainerLocation.AuxiliaryBar);
 						break;
 				}
 			});


### PR DESCRIPTION
Allows extensions to contribute views to auxiliary bar (secondary side bar)
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `auxiliarybar` contribution point to allow extensions to contribute views containers to the Secondary Side Bar.
> 
>   - **Behavior**:
>     - Add `auxiliarybar` contribution point to `viewsContainersContribution` in `viewsExtensionPoint.ts`.
>     - Update `ViewsExtensionHandler` to handle `auxiliarybar` in `addCustomViewContainers()` and `registerCustomViewContainers()`.
>   - **Order Management**:
>     - Introduce `auxiliaryBarOrder` for managing order of auxiliary bar containers in `addCustomViewContainers()`.
>   - **Misc**:
>     - Update `localize` descriptions for `auxiliarybar` in `viewsContainersContribution`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 364d8d59bdfc421a29f982da7175b1d20fe3c3fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->