### PR TITLE
Make Aux bar exclusive to PearAI extensions

### DIFF
--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -26,6 +26,7 @@ import { registerIcon } from '../../platform/theme/common/iconRegistry.js';
 import { CancellationToken } from '../../base/common/cancellation.js';
 import { VSDataTransfer } from '../../base/common/dataTransfer.js';
 import { ILocalizedString } from '../../platform/action/common/action.js';
+import { auxiliaryBarAllowedViewContainerIDs } from '../services/views/pearai/pearaiViewsShared.js';
 
 export const VIEWS_LOG_ID = 'views';
 export const VIEWS_LOG_NAME = localize('views log', "Views");
@@ -255,7 +256,21 @@ class ViewContainersRegistryImpl extends Disposable implements IViewContainersRe
 	}
 }
 
-Registry.add(Extensions.ViewContainersRegistry, new ViewContainersRegistryImpl());
+
+class PearAIViewContainersRegistryImpl extends ViewContainersRegistryImpl implements IViewContainersRegistry {
+	override registerViewContainer(viewContainerDescriptor: IViewContainerDescriptor, viewContainerLocation: ViewContainerLocation, options?: { isDefault?: boolean; doNotRegisterOpenCommand?: boolean }): ViewContainer {
+	  // Register to sidebar instead of aux bar if non pearai integration
+	  if (
+		viewContainerLocation === ViewContainerLocation.AuxiliaryBar &&
+		!auxiliaryBarAllowedViewContainerIDs.includes(viewContainerDescriptor.id)
+	  ) {
+		viewContainerLocation = ViewContainerLocation.Sidebar;
+	  }
+	  return super.registerViewContainer(viewContainerDescriptor, viewContainerLocation, options);
+	}
+  }
+
+Registry.add(Extensions.ViewContainersRegistry, new PearAIViewContainersRegistryImpl());
 
 export interface IViewDescriptor {
 

--- a/src/vs/workbench/services/views/pearai/pearaiViews.ts
+++ b/src/vs/workbench/services/views/pearai/pearaiViews.ts
@@ -1,4 +1,4 @@
-import { ViewContainer, ViewContainerLocation } from 'vs/workbench/common/views';
+import { ViewContainer, ViewContainerLocation } from '../../../common/views.js';
 
 import { IExtensionService } from '../../extensions/common/extensions.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
@@ -8,11 +8,9 @@ import { IContextKeyService } from '../../../../platform/contextkey/common/conte
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
 import { ILoggerService } from '../../../../platform/log/common/log.js';
 import { ViewDescriptorService } from '../browser/viewDescriptorService.js';
+import { auxiliaryBarAllowedViewContainerIDs } from './pearaiViewsShared.js';
 
-
-const auxiliaryBarAllowedViewContainerIDs = ['workbench.view.extension.PearAI'];
-
-export class CustomViewDescriptorService extends ViewDescriptorService implements IViewDescriptorService {
+export class PearAIViewDescriptorService extends ViewDescriptorService implements IViewDescriptorService {
 	constructor(
         @IInstantiationService instantiationService: IInstantiationService,
         @IContextKeyService contextKeyService: IContextKeyService,
@@ -29,15 +27,23 @@ export class CustomViewDescriptorService extends ViewDescriptorService implement
     viewContainer: ViewContainer,
     location: ViewContainerLocation,
   ): void {
+
+    // Prevent other views to move into aux bar
     if (
       location === ViewContainerLocation.AuxiliaryBar &&
       !auxiliaryBarAllowedViewContainerIDs.includes(viewContainer.id)
     ) {
-      // Prevent the move since the ViewContainer ID is not in the allowed list
       return;
     }
 
-    // Call the original method to proceed with the move
+    // Prevent PearAI integrations to move out of aux bar
+    if (
+      location !== ViewContainerLocation.AuxiliaryBar &&
+      auxiliaryBarAllowedViewContainerIDs.includes(viewContainer.id)
+    ) {
+      return;
+    }
     super.moveViewContainerToLocation(viewContainer, location);
   }
 }
+

--- a/src/vs/workbench/services/views/pearai/pearaiViews.ts
+++ b/src/vs/workbench/services/views/pearai/pearaiViews.ts
@@ -1,0 +1,43 @@
+import { ViewContainer, ViewContainerLocation } from 'vs/workbench/common/views';
+
+import { IExtensionService } from '../../extensions/common/extensions.js';
+import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { IViewDescriptorService } from '../../../common/views.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IStorageService } from '../../../../platform/storage/common/storage.js';
+import { ILoggerService } from '../../../../platform/log/common/log.js';
+import { ViewDescriptorService } from '../browser/viewDescriptorService.js';
+
+
+const auxiliaryBarAllowedViewContainerIDs = ['workbench.view.extension.PearAI'];
+
+export class CustomViewDescriptorService extends ViewDescriptorService implements IViewDescriptorService {
+	constructor(
+        @IInstantiationService instantiationService: IInstantiationService,
+        @IContextKeyService contextKeyService: IContextKeyService,
+        @IStorageService storageService: IStorageService,
+        @IExtensionService extensionService: IExtensionService,
+        @ITelemetryService telemetryService: ITelemetryService,
+        @ILoggerService loggerService: ILoggerService,
+    ) {
+        super(instantiationService, contextKeyService, storageService, extensionService, telemetryService, loggerService);
+	}
+
+
+  override moveViewContainerToLocation(
+    viewContainer: ViewContainer,
+    location: ViewContainerLocation,
+  ): void {
+    if (
+      location === ViewContainerLocation.AuxiliaryBar &&
+      !auxiliaryBarAllowedViewContainerIDs.includes(viewContainer.id)
+    ) {
+      // Prevent the move since the ViewContainer ID is not in the allowed list
+      return;
+    }
+
+    // Call the original method to proceed with the move
+    super.moveViewContainerToLocation(viewContainer, location);
+  }
+}

--- a/src/vs/workbench/services/views/pearai/pearaiViewsShared.ts
+++ b/src/vs/workbench/services/views/pearai/pearaiViewsShared.ts
@@ -1,0 +1,1 @@
+export const auxiliaryBarAllowedViewContainerIDs = ['workbench.view.extension.PearAI'];

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -162,8 +162,7 @@ registerSingleton(IContextKeyService, ContextKeyService, InstantiationType.Delay
 registerSingleton(ITextResourceConfigurationService, TextResourceConfigurationService, InstantiationType.Delayed);
 registerSingleton(IDownloadService, DownloadService, InstantiationType.Delayed);
 registerSingleton(IOpenerService, OpenerService, InstantiationType.Delayed);
-registerSingleton(IViewDescriptorService, CustomViewDescriptorService, InstantiationType.Delayed);
-
+registerSingleton(IViewDescriptorService, PearAIViewDescriptorService, InstantiationType.Delayed);
 
 //#endregion
 
@@ -405,7 +404,6 @@ import './contrib/inlineCompletions/browser/inlineCompletions.contribution.js';
 import './contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js';
 import { AllowedExtensionsService } from '../platform/extensionManagement/common/allowedExtensionsService.js';
 import { IViewDescriptorService } from './common/views.js';
-import { CustomViewDescriptorService } from './services/views/pearai/pearaiViews.js';
-
+import { PearAIViewDescriptorService } from './services/views/pearai/pearaiViews.js';
 
 //#endregion

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -162,6 +162,8 @@ registerSingleton(IContextKeyService, ContextKeyService, InstantiationType.Delay
 registerSingleton(ITextResourceConfigurationService, TextResourceConfigurationService, InstantiationType.Delayed);
 registerSingleton(IDownloadService, DownloadService, InstantiationType.Delayed);
 registerSingleton(IOpenerService, OpenerService, InstantiationType.Delayed);
+registerSingleton(IViewDescriptorService, CustomViewDescriptorService, InstantiationType.Delayed);
+
 
 //#endregion
 
@@ -402,6 +404,8 @@ import './contrib/inlineCompletions/browser/inlineCompletions.contribution.js';
 // Drop or paste into
 import './contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js';
 import { AllowedExtensionsService } from '../platform/extensionManagement/common/allowedExtensionsService.js';
+import { IViewDescriptorService } from './common/views.js';
+import { CustomViewDescriptorService } from './services/views/pearai/pearaiViews.js';
 
 
 //#endregion


### PR DESCRIPTION
https://drive.google.com/file/d/1JAl1G96p0ZeQ3eN3ax5meh_C1bCzObwx/view?usp=drive_link


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts Auxiliary Bar to PearAI extensions by modifying view container registration and movement logic.
> 
>   - **Behavior**:
>     - Restricts Auxiliary Bar to PearAI extensions by checking `auxiliaryBarAllowedViewContainerIDs` in `PearAIViewContainersRegistryImpl` and `PearAIViewDescriptorService`.
>     - Non-PearAI view containers are moved to Sidebar if attempted to register in Auxiliary Bar.
>     - PearAI view containers are prevented from moving out of Auxiliary Bar.
>   - **Classes**:
>     - `PearAIViewContainersRegistryImpl` extends `ViewContainersRegistryImpl` to override `registerViewContainer()`.
>     - `PearAIViewDescriptorService` extends `ViewDescriptorService` to override `moveViewContainerToLocation()`.
>   - **Misc**:
>     - Registers `PearAIViewDescriptorService` as `IViewDescriptorService` in `workbench.common.main.ts`.
>     - Adds `pearaiViews.ts` and `pearaiViewsShared.ts` for PearAI-specific logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for f5b47b0ab059de6fb29e7518646c33bef3776951. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->