### PR TITLE
Update install dependency script to use npm instead of yarn

### DIFF
--- a/scripts/pearai/install-dependencies.sh
+++ b/scripts/pearai/install-dependencies.sh
@@ -20,8 +20,8 @@ execute "cd $submodule_dir" "Failed to change directory to $submodule_dir"
 execute "./scripts/install-and-build.sh" "Failed to install dependencies for the submodule"
 execute "cd ../../" "Failed to change back to the root directory"
 
-# Install dependencies using yarn
-execute "yarn" "Failed to install dependencies using yarn"
+# Install dependencies using npm
+execute "npm install" "Failed to install dependencies with npm"
 
 # Success message
 echo "Dependencies Installed Completed Successfully! ⭐"


### PR DESCRIPTION
## Description

Yarn is no longer supported in the PearAI project and we've migrated to NPM. For example, in the `setup-environment.sh` script we install our dependencies with npm ([Code Ref](https://github.com/trypear/pearai-app/blob/main/scripts/pearai/setup-environment.sh#L98) and [commit where this was changed](https://github.com/trypear/pearai-app/commit/1feef3b45a93bd053bae763c87263ffa96b20551)).

This PR updates the `install-dependencies.sh` to use NPM as well instead of yarn.

## Testing Details
Ran the script from the pearai-app root with:
```
./scripts/pearai/install-dependencies.sh
```

**Before:**
<img width="1066" alt="2025-02-09 19 28 02" src="https://github.com/user-attachments/assets/1903ef34-68d3-4880-b281-a5f8a7216829" />
**After:**
<img width="468" alt="2025-02-09 19 28 14" src="https://github.com/user-attachments/assets/cd30edab-5176-47d4-b70f-30958d4f3ddb" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `install-dependencies.sh` to use npm instead of yarn for dependency installation.
> 
>   - **Behavior**:
>     - Update `install-dependencies.sh` to use `npm install` instead of `yarn` for installing dependencies.
>   - **Scripts**:
>     - Modify `install-dependencies.sh` to reflect the change from yarn to npm.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 2b0b930d4c512dd88bfe15440975188563dd52d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->