### PR TITLE
Fixed iconbar sync state

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -73,6 +73,7 @@ import { DynamicEditorConfigurations } from './editorConfiguration.js';
 import { ConfigureEditorAction, ConfigureEditorTabsAction, EditorActionsDefaultAction, EditorActionsTitleBarAction, HideEditorActionsAction, HideEditorTabsAction, ShowMultipleEditorTabsAction, ShowSingleEditorTabAction, ZenHideEditorTabsAction, ZenShowMultipleEditorTabsAction, ZenShowSingleEditorTabAction } from '../../actions/layoutActions.js';
 import { ICommandAction } from '../../../../platform/action/common/action.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
+import { SwitchToPearAIIntegrationAction } from '../panel/panelActions.js';
 
 //#region Editor Registrations
 
@@ -308,6 +309,9 @@ registerAction2(MoveEditorGroupToNewWindowAction);
 registerAction2(CopyEditorGroupToNewWindowAction);
 registerAction2(RestoreEditorsToMainWindowAction);
 registerAction2(NewEmptyEditorWindowAction);
+
+// PearAI IconBar
+registerAction2(SwitchToPearAIIntegrationAction);
 
 const quickAccessNavigateNextInEditorPickerId = 'workbench.action.quickOpenNavigateNextInEditorPicker';
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -118,7 +118,7 @@ interface IInventoryIcon {
 class InventoryIcons {
 	private static readonly icons: readonly IInventoryIcon[] = [
 		{ id: 'chat', icon: 'inventory-chat-icon', label: 'Chat', command: 'pearai.chatView.focus', width: 10, containerId: 'pearaichat' },
-		{ id: 'agent', icon: 'inventory-creator-icon', label: 'Agent', command: 'roo-cline.SidebarProvider.focus', width: 80, containerId: 'pearaiagent' },
+		{ id: 'agent', icon: 'inventory-creator-icon', label: 'Agent', command: 'pearai-roo-cline.SidebarProvider.focus', width: 80, containerId: 'pearaiagent' },
 		{ id: 'search', icon: 'inventory-search-icon', label: 'Search', command: 'pearai.searchView.focus', width: 75, containerId: 'pearaisearch' },
 		{ id: 'memory', icon: 'inventory-memory-icon', label: 'Memory', command: 'pearai.mem0View.focus', width: 85, containerId: 'pearaimemory' }
 	] as const;

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -394,7 +394,7 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
 	readonly PearAIChatExtensionId;
 	readonly PearAISearchExtensionId;
 	readonly PearAIMemoryExtensionId;
-	readonly PearAIROOExtensionId;
+	readonly PearAIRooExtensionId;
 
     constructor() {
         super(ViewContainerLocation.Sidebar, ViewContainerLocation.AuxiliaryBar, {
@@ -406,7 +406,7 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
         this.PearAIChatExtensionId = 'workbench.view.extension.pearaiChat';
 		this.PearAISearchExtensionId = 'workbench.view.extension.pearaiSearch';
 		this.PearAIMemoryExtensionId = 'workbench.view.extension.pearaiMemory';
-		this.PearAIROOExtensionId = 'workbench.view.extension.pearai-roo-cline';
+		this.PearAIRooExtensionId = 'workbench.view.extension.pearai-roo-cline';
     }
 
     override run(accessor: ServicesAccessor): void {
@@ -417,8 +417,8 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
         const chatViewContainer = viewDescriptorService.getViewContainerById(this.PearAIChatExtensionId);
 		const searchViewContainer = viewDescriptorService.getViewContainerById(this.PearAISearchExtensionId);
 		const memoryViewContainer = viewDescriptorService.getViewContainerById(this.PearAIMemoryExtensionId);
-		const creatorViewContainer = viewDescriptorService.getViewContainerById(this.PearAIROOExtensionId);
-		
+		const agentViewContainer = viewDescriptorService.getViewContainerById(this.PearAIRooExtensionId);
+
 		const destination = ViewContainerLocation.AuxiliaryBar;
 
         if (chatViewContainer) {
@@ -436,10 +436,10 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
             layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
             // viewsService.openViewContainer(memoryViewContainer.id, true);
         }
-		if (creatorViewContainer) {
-            viewDescriptorService.moveViewContainerToLocation(creatorViewContainer, destination, undefined, this.desc.id);
+		if (agentViewContainer) {
+            viewDescriptorService.moveViewContainerToLocation(agentViewContainer, destination, undefined, this.desc.id);
             layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-            // viewsService.openViewContainer(creatorViewContainer.id, true);
+            // viewsService.openViewContainer(agentViewContainer.id, true);
         }
     }
 }

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -15,6 +15,7 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { ViewContainerLocationToString, ViewContainerLocation, IViewDescriptorService } from '../../../common/views.js';
+import { PearAIChatExtensionId, PearAISearchExtensionId, PearAIMemoryExtensionId, PearAIRooExtensionId, PearAIView, PEARAI_VIEWS} from '../../../services/views/pearai/pearaiViewsShared.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
@@ -27,6 +28,31 @@ const restoreIcon = registerIcon('panel-restore', Codicon.chevronDown, localize(
 const closeIcon = registerIcon('panel-close', Codicon.close, localize('closeIcon', 'Icon to close a panel.'));
 const panelIcon = registerIcon('panel-layout-icon', Codicon.layoutPanel, localize('togglePanelOffIcon', 'Icon to toggle the panel off when it is on.'));
 const panelOffIcon = registerIcon('panel-layout-icon-off', Codicon.layoutPanelOff, localize('togglePanelOnIcon', 'Icon to toggle the panel on when it is off.'));
+
+export class SwitchToPearAIIntegrationAction extends Action2 {
+  static readonly ID = 'workbench.action.switchToPearAIIntegrationIconBar';
+
+  constructor() {
+    super({
+      id: SwitchToPearAIIntegrationAction.ID,
+    title: localize2('switchToPearAIView', "Switch to PearAI Integration"),
+    category: Categories.View,
+    f1: true
+    });
+  }
+
+  override async run(accessor: ServicesAccessor, args?: { view: PearAIView }): Promise<void> {
+    const view = args?.view || 'chat'; // default to chat if no view specified
+    const viewsService = accessor.get(IViewsService);
+    const layoutService = accessor.get(IWorkbenchLayoutService);
+
+    if (!layoutService.isVisible(Parts.AUXILIARYBAR_PART)) {
+    layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+    }
+
+    await viewsService.openView(PEARAI_VIEWS[view], true);
+  }
+}
 
 export class TogglePanelAction extends Action2 {
 
@@ -391,10 +417,6 @@ class MoveViewsBetweenPanelsAction extends Action2 {
 // Move Pear AI extension to PearAI Side Bar (Auxiliary Bar) (we want PearAI Side Bar to be default loaction for extension)
 class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
     static readonly ID = 'workbench.action.movePearExtensionToAuxBar';
-	readonly PearAIChatExtensionId;
-	readonly PearAISearchExtensionId;
-	readonly PearAIMemoryExtensionId;
-	readonly PearAIRooExtensionId;
 
     constructor() {
         super(ViewContainerLocation.Sidebar, ViewContainerLocation.AuxiliaryBar, {
@@ -403,10 +425,6 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
             category: Categories.View,
             f1: true
         });
-        this.PearAIChatExtensionId = 'workbench.view.extension.pearaiChat';
-		this.PearAISearchExtensionId = 'workbench.view.extension.pearaiSearch';
-		this.PearAIMemoryExtensionId = 'workbench.view.extension.pearaiMemory';
-		this.PearAIRooExtensionId = 'workbench.view.extension.pearai-roo-cline';
     }
 
     override run(accessor: ServicesAccessor): void {
@@ -414,34 +432,34 @@ class MovePearExtensionToAuxBarAction extends MoveViewsBetweenPanelsAction {
         const layoutService = accessor.get(IWorkbenchLayoutService);
         const viewsService = accessor.get(IViewsService);
 
-        const chatViewContainer = viewDescriptorService.getViewContainerById(this.PearAIChatExtensionId);
-		const searchViewContainer = viewDescriptorService.getViewContainerById(this.PearAISearchExtensionId);
-		const memoryViewContainer = viewDescriptorService.getViewContainerById(this.PearAIMemoryExtensionId);
-		const agentViewContainer = viewDescriptorService.getViewContainerById(this.PearAIRooExtensionId);
+        const chatViewContainer = viewDescriptorService.getViewContainerById(PearAIChatExtensionId);
+        const searchViewContainer = viewDescriptorService.getViewContainerById(PearAISearchExtensionId);
+        const memoryViewContainer = viewDescriptorService.getViewContainerById(PearAIMemoryExtensionId);
+        const agentViewContainer = viewDescriptorService.getViewContainerById(PearAIRooExtensionId);
 
-		const destination = ViewContainerLocation.AuxiliaryBar;
+        const destination = ViewContainerLocation.AuxiliaryBar;
 
         if (chatViewContainer) {
             viewDescriptorService.moveViewContainerToLocation(chatViewContainer, destination, undefined, this.desc.id);
             layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
             viewsService.openViewContainer(chatViewContainer.id, true);
         }
-		if (searchViewContainer) {
-            viewDescriptorService.moveViewContainerToLocation(searchViewContainer, destination, undefined, this.desc.id);
-            layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-            // viewsService.openViewContainer(searchViewContainer.id, true);
+        if (searchViewContainer) {
+                viewDescriptorService.moveViewContainerToLocation(searchViewContainer, destination, undefined, this.desc.id);
+                layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+                // viewsService.openViewContainer(searchViewContainer.id, true);
+            }
+        if (memoryViewContainer) {
+                viewDescriptorService.moveViewContainerToLocation(memoryViewContainer, destination, undefined, this.desc.id);
+                layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+                // viewsService.openViewContainer(memoryViewContainer.id, true);
+            }
+        if (agentViewContainer) {
+                viewDescriptorService.moveViewContainerToLocation(agentViewContainer, destination, undefined, this.desc.id);
+                layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
+                // viewsService.openViewContainer(agentViewContainer.id, true);
+            }
         }
-		if (memoryViewContainer) {
-            viewDescriptorService.moveViewContainerToLocation(memoryViewContainer, destination, undefined, this.desc.id);
-            layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-            // viewsService.openViewContainer(memoryViewContainer.id, true);
-        }
-		if (agentViewContainer) {
-            viewDescriptorService.moveViewContainerToLocation(agentViewContainer, destination, undefined, this.desc.id);
-            layoutService.setPartHidden(false, Parts.AUXILIARYBAR_PART);
-            // viewsService.openViewContainer(agentViewContainer.id, true);
-        }
-    }
 }
 
 registerAction2(MovePearExtensionToAuxBarAction);

--- a/src/vs/workbench/services/views/pearai/pearaiViewsShared.ts
+++ b/src/vs/workbench/services/views/pearai/pearaiViewsShared.ts
@@ -1,2 +1,16 @@
+export type PearAIView = 'chat' | 'agent' | 'search' | 'memory';
+
+export const PearAIChatExtensionId = 'workbench.view.extension.pearaiChat';
+export const PearAISearchExtensionId = 'workbench.view.extension.pearaiSearch';
+export const PearAIMemoryExtensionId = 'workbench.view.extension.pearaiMemory';
+export const PearAIRooExtensionId = 'workbench.view.extension.pearai-roo-cline';
+
+export const PEARAI_VIEWS = {
+  chat: PearAIChatExtensionId,
+  agent: PearAIRooExtensionId,
+  search: PearAISearchExtensionId,
+  memory: PearAIMemoryExtensionId
+} as const;
+
 export const auxiliaryBarAllowedViewContainerIDs = ['workbench.view.extension.pearai', 'workbench.view.extension.pearai-roo-cline', 'workbench.views.service.auxiliarybar'];
 // auxiliary bar here is needed because additional views created by our integrations look like: workbench.views.service.auxiliarybar.c01af9cf-6360-4e6a-a725-4dfd9832755c


### PR DESCRIPTION
https://github.com/trypear/pearai-app/issues/189
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Synchronizes PearAI icon bar state by adding a new action and updating commands for PearAI views.
> 
>   - **Behavior**:
>     - Adds `SwitchToPearAIIntegrationAction` in `panelActions.ts` to switch to PearAI integration, defaulting to 'chat' view.
>     - Registers `SwitchToPearAIIntegrationAction` in `editor.contribution.ts`.
>     - Updates command for 'agent' icon in `paneCompositePart.ts` to `pearai-roo-cline.SidebarProvider.focus`.
>   - **Views**:
>     - Adds `PearAIView` type and `PEARAI_VIEWS` mapping in `pearaiViewsShared.ts`.
>     - Updates `MovePearExtensionToAuxBarAction` to use constants from `pearaiViewsShared.ts`.
>   - **Misc**:
>     - Removes redundant extension ID properties from `MovePearExtensionToAuxBarAction` in `panelActions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for bd8f61f01385b7e1519b63a40ca3efd654648d49. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->