### PR TITLE
winupdate: autocheck - manual download

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -149,6 +149,7 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 				this.nativeHostMainService.openExternal(undefined, state.update.url);
 			}
 			this.setState(State.Idle(getUpdateType()));
+			return;
 		}
 
 		if (this.state.type !== StateType.AvailableForDownload)

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -130,47 +130,11 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 					return Promise.resolve(null);
 				}
 
-				if (updateType === UpdateType.Archive) {
-					this.setState(State.AvailableForDownload(update));
-					return Promise.resolve(null);
-				}
-
-				this.setState(State.Downloading);
-
-				return this.cleanup(update.version).then(() => {
-					return this.getUpdatePackagePath(update.version).then(updatePackagePath => {
-						return pfs.Promises.exists(updatePackagePath).then(exists => {
-							if (exists) {
-								return Promise.resolve(updatePackagePath);
-							}
-
-							const downloadPath = `${updatePackagePath}.tmp`;
-
-							return this.requestService.request({ url: update.url }, CancellationToken.None)
-								.then(context => this.fileService.writeFile(URI.file(downloadPath), context.stream))
-								.then(update.sha256hash ? () => checksum(downloadPath, update.sha256hash) : () => undefined)
-								.then(() => pfs.Promises.rename(downloadPath, updatePackagePath, false /* no retry */))
-								.then(() => updatePackagePath);
-						});
-					}).then(packagePath => {
-						this.availableUpdate = { packagePath };
-						this.setState(State.Downloaded(update));
-						// NOTE: pear does not support fast updates. so we are setting the state to ready.
-						this.setState(State.Ready(update));
-
-						// const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
-						// if (fastUpdatesEnabled) {
-						// 	if (this.productService.target === 'user') {
-						// 		this.doApplyUpdate();
-						// 	}
-						// } else {
-						// 	this.setState(State.Ready(update));
-						// }
-					});
-				});
+				this.setState(State.AvailableForDownload(update));
+				return Promise.resolve(null);
 			})
 			.then(undefined, err => {
-				this.telemetryService.publicLog2<{ messageHash: string }, UpdateErrorClassification>('update:error', { messageHash: String(hash(String(err))) });
+				this.telemetryService.publicLog2<{ messageHash: string }, UpdateErrorClassification>('updateCheck:error', { messageHash: String(hash(String(err))) });
 				this.logService.error(err);
 
 				// only show message when explicitly checking for updates
@@ -180,10 +144,51 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 	}
 
 	protected override async doDownloadUpdate(state: AvailableForDownload): Promise<void> {
-		if (state.update.url) {
-			this.nativeHostMainService.openExternal(undefined, state.update.url);
+		if (getUpdateType() === UpdateType.Archive) {
+			if (state.update.url) {
+				this.nativeHostMainService.openExternal(undefined, state.update.url);
+			}
+			this.setState(State.Idle(getUpdateType()));
 		}
-		this.setState(State.Idle(getUpdateType()));
+
+		if (this.state.type !== StateType.AvailableForDownload)
+			return;
+
+		const update = this.state.update;
+
+		this.setState(State.Downloading);
+
+		return this.cleanup(update.version).then(() => {
+			return this.getUpdatePackagePath(update.version).then(updatePackagePath => {
+				return pfs.Promises.exists(updatePackagePath).then(exists => {
+					if (exists) {
+						return Promise.resolve(updatePackagePath);
+					}
+
+					const downloadPath = `${updatePackagePath}.tmp`;
+
+					return this.requestService.request({ url: update.url }, CancellationToken.None)
+						.then(context => this.fileService.writeFile(URI.file(downloadPath), context.stream))
+						.then(update.sha256hash ? () => checksum(downloadPath, update.sha256hash) : () => undefined)
+						.then(() => pfs.Promises.rename(downloadPath, updatePackagePath, false /* no retry */))
+						.then(() => updatePackagePath);
+				});
+			}).then(packagePath => {
+				this.availableUpdate = { packagePath };
+				this.setState(State.Downloaded(update));
+				// NOTE: pear does not support fast updates. so we are setting the state to ready.
+				this.setState(State.Ready(update));
+
+				// const fastUpdatesEnabled = this.configurationService.getValue('update.enableWindowsBackgroundUpdates');
+				// if (fastUpdatesEnabled) {
+				// 	if (this.productService.target === 'user') {
+				// 		this.doApplyUpdate();
+				// 	}
+				// } else {
+				// 	this.setState(State.Ready(update));
+				// }
+			});
+		});
 	}
 
 	private async getUpdatePackagePath(version: string): Promise<string> {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -481,7 +481,7 @@
 	align-items: center;
 	justify-content: center;
 	cursor: pointer;
-	border-radius: 16px;
+	border-radius: 8px;
 	padding: 6px 8px;
 	margin: 5px 6px;
 	color: var(--vscode-button-foreground);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor Windows update process to separate download initiation and reduce update button border-radius in CSS.
> 
>   - **Update Process**:
>     - Moved download logic from `doCheckForUpdates` to `doDownloadUpdate` in `updateService.win32.ts`.
>     - `doCheckForUpdates` now sets state to `AvailableForDownload` for all updates.
>     - `doDownloadUpdate` handles both `Archive` and `Setup` update types, initiating download for `Setup` type.
>   - **CSS**:
>     - Changed `border-radius` from `16px` to `8px` for `.update-button` in `titlebarpart.css`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 89faacbfaf8599dbea7939c00abfe3312120237f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->