### PR TITLE
aux bar height fix

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -14,10 +14,9 @@
 	height: 100%;
 }
 
-.monaco-workbench .part.auxiliarybar > .content {
-	flex: 1;
-	min-height: 0; /* Required for proper flex behavior */
-	position: relative;
+.monaco-workbench .part.auxiliarybar > .content .split-view-view {
+    position: relative !important;
+    height: 100% !important;
 }
 
 .monaco-workbench .part.auxiliarybar > .content .monaco-editor,
@@ -37,15 +36,16 @@
 .monaco-workbench .part.auxiliarybar > .title {
 	background-color: var(--vscode-sideBarTitle-background);
 	padding: 0px;
-	margin-top: 6px;
-	margin-left: 12px;
+	margin-top: 7px;
+	padding-left: 7px;
 	margin-right: 12px;
 	margin-bottom: 0px;
 	flex: 0 0 auto;
-	/* min-height: 34px; */
+	/* min-height: 84px; */
 	display: flex;
 	align-items: center;
 	position: relative;
+	/* border: 1px solid red; */
 	/* z-index: 20000; */
 }
 
@@ -67,7 +67,7 @@
 	padding: 4px;
 	justify-content: flex-start;
 	align-items: center;
-	gap: 4px;
+	gap: 3px;
 	border-radius: 12px;
 	background: var(--vscode-sideBar-background);
 	box-shadow: 0px 0px 0px 1px var(--vscode-badge-background) inset;


### PR DESCRIPTION
RESIZING IS CAUSING HEIGHT CHANGES, not full fix, but does the job.
not sure how to do exact fix.




https://github.com/user-attachments/assets/ccbaa443-4da0-4a69-a83e-c8d4fcfea9ec


<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjust auxiliary bar layout and styling in `auxiliaryBarPart.css` for improved consistency.
> 
>   - **Layout Adjustments**:
>     - `.monaco-workbench .part.auxiliarybar > .content .split-view-view` now has `position: relative !important;` and `height: 100% !important;`.
>     - `.monaco-workbench .part.auxiliarybar > .title` margin-top changed from `6px` to `7px`, and padding-left added with `7px`.
>   - **Styling Changes**:
>     - `.monaco-workbench .part.auxiliarybar .icon-group` gap reduced from `4px` to `3px`.
>     - Commented out `min-height` and `border` properties in `.monaco-workbench .part.auxiliarybar > .title`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 09cf78834a79a021884bb9464ac85752a2983b53. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->