### PR TITLE
switch chat agent

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -117,8 +117,8 @@ interface IInventoryIcon {
 
 class InventoryIcons {
 	private static readonly icons: readonly IInventoryIcon[] = [
-		{ id: 'chat', icon: 'inventory-chat-icon', label: 'Chat', command: 'pearai.chatView.focus', width: 10, containerId: 'pearaichat' },
 		{ id: 'agent', icon: 'inventory-creator-icon', label: 'Agent', command: 'pearai-roo-cline.SidebarProvider.focus', width: 80, containerId: 'pearaiagent' },
+		{ id: 'chat', icon: 'inventory-chat-icon', label: 'Chat', command: 'pearai.chatView.focus', width: 10, containerId: 'pearaichat' },
 		{ id: 'search', icon: 'inventory-search-icon', label: 'Search', command: 'pearai.searchView.focus', width: 75, containerId: 'pearaisearch' },
 		{ id: 'memory', icon: 'inventory-memory-icon', label: 'Memory', command: 'pearai.mem0View.focus', width: 85, containerId: 'pearaimemory' }
 	] as const;
@@ -164,7 +164,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 	private blockOpening = false;
 	protected contentDimension: Dimension | undefined;
 
-	private activeInventoryIcon: string | undefined = 'chat';
+	private activeInventoryIcon: string | undefined = 'agent';
 
 	constructor(
 		readonly partId: Parts.PANEL_PART | Parts.AUXILIARYBAR_PART | Parts.SIDEBAR_PART,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder inventory icons and change default active icon to `agent` in `paneCompositePart.ts`.
> 
>   - **Behavior**:
>     - Reorder inventory icons in `InventoryIcons` class to place `agent` before `chat`.
>     - Change default `activeInventoryIcon` from `chat` to `agent` in `AbstractPaneCompositePart` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 58a0aa655a2561c2f64466775bdfb2b13f32fcb6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->