### PR TITLE
Fix PearAI inventory search icon container width

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -114,7 +114,7 @@
 
 .monaco-workbench .part.auxiliarybar .icon-group .icon-container.active:has(.inventory-search-icon) {
 	z-index: 2 !important;
-    width: 70px !important;
+    width: 73px !important;
 }
 
 .monaco-workbench .part.auxiliarybar .icon-group .icon-container.active:has(.inventory-memory-icon) {


### PR DESCRIPTION
### Summary
Fix the width of the search icon

### Testing Details
Launched Pear app with `yarn watch` and `./scripts/code.sh`. Visually checked width to make sure it looked right.
<img width="259" alt="image" src="https://github.com/user-attachments/assets/6db4b16a-05da-4460-a532-bbdbb951ee2d" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts the width of the active inventory search icon container in `auxiliaryBarPart.css` from 70px to 73px.
> 
>   - **CSS Adjustment**:
>     - In `auxiliaryBarPart.css`, change the width of `.icon-container.active:has(.inventory-search-icon)` from `70px` to `73px`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for b70a0bd04bd0f8dac55570374e2ca219f9910ca2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->