### PR TITLE
Fix: yarn tsc-watch -> npm run tsc-watch in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To rebuild the app after initial setup:
 2. For watching extension - open another terminal and run:
    ```bash
    cd extensions/pearai-submodule/extensions/vscode
-   yarn tsc-watch
+   npm run tsc-watch
    ```
 3. Open another terminal to run the app:
    - **macOS and Linux**:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `yarn tsc-watch` with `npm run tsc-watch` in `CONTRIBUTING.md` for correct extension watching command.
> 
>   - **Documentation**:
>     - In `CONTRIBUTING.md`, replace `yarn tsc-watch` with `npm run tsc-watch` for watching extensions in the PearAI app.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 212969145d293ea5ceb2b4ddee75b08ffef2f2a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->