### PR TITLE
Feat: setting default theme to dark on startup

### DIFF
--- a/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
+++ b/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
@@ -30,6 +30,8 @@ import { URI } from "../../../../base/common/uri.js";
 import { ExtensionIdentifier } from "../../../../platform/extensions/common/extensions.js";
 import { IEditorGroupsService } from "../../../../workbench/services/editor/common/editorGroupsService.js";
 import { PEARAI_FIRST_LAUNCH_KEY } from "./common.js";
+import * as vscode from 'vscode';
+
 
 // const PEARAI_FIRST_LAUNCH_KEY = "pearai.firstLaunch";
 
@@ -93,6 +95,9 @@ export class PearOverlayPart extends Part {
 		if (this.isFirstLaunch) {
 			this.state = "open";
 			this.lock();
+
+			// setting the theme to PearAI Dark on first launch here to avoid flicker
+			vscode.workspace.getConfiguration().update('workbench.colorTheme', "Default PearAI Dark", true);
 		} else {
 			this.state = "closed";
 		}
@@ -207,6 +212,7 @@ export class PearOverlayPart extends Part {
 		this.element.appendChild(this.popupAreaOverlay);
 
 		if (this.isFirstLaunch) {
+
 			// Create loading overlay with higher z-index and pointer-events handling
 			this.loadingOverlay = $('div.pearai-loading-overlay');
 			this.loadingOverlay.style.position = 'fixed'; // Change to fixed positioning


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets default theme to 'Default PearAI Dark' on first launch in `PearOverlayPart` to avoid flicker.
> 
>   - **Behavior**:
>     - Sets default theme to 'Default PearAI Dark' on first launch in `initialize()` of `PearOverlayPart` to avoid flicker.
>     - Uses `vscode.workspace.getConfiguration().update()` to change theme setting.
>   - **Conditions**:
>     - Only applies on first launch, determined by `isFirstLaunch` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for b7231714be541f97f841f5a4ffc99dadd5b1d65c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->