### PR TITLE
theme-fix-menu-foreground

### DIFF
--- a/extensions/theme-defaults/themes/pearai_dark.json
+++ b/extensions/theme-defaults/themes/pearai_dark.json
@@ -54,6 +54,7 @@
 		"inputOption.activeBackground": "#FFFFFF82",
 		"inputOption.activeBorder": "#FFFFFF",
 		"keybindingLabel.foreground": "#CCCCCC",
+		"menu.selectionForeground": "#000000",
 		"menu.background": "#1F1F1F",
 		"menu.selectionBackground": "#FFFFFF",
 		"notificationCenterHeader.background": "#1F1F1F",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `menu.selectionForeground` to `pearai_dark.json` to set menu selection text color to black.
> 
>   - **Theme Update**:
>     - Adds `menu.selectionForeground` with value `#000000` to `pearai_dark.json` to set menu selection text color to black.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 1cbb7bbd21175274f698039e5a5f5234e44545e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->