### PR TITLE
react-render-on-overlay-open

### DIFF
--- a/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
+++ b/src/vs/workbench/browser/parts/overlay/pearOverlayPart.ts
@@ -31,6 +31,7 @@ import { ExtensionIdentifier } from "../../../../platform/extensions/common/exte
 import { IEditorGroupsService } from "../../../../workbench/services/editor/common/editorGroupsService.js";
 import { PEARAI_FIRST_LAUNCH_KEY } from "./common.js";
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 
 // const PEARAI_FIRST_LAUNCH_KEY = "pearai.firstLaunch";
@@ -68,6 +69,7 @@ export class PearOverlayPart extends Part {
 		private readonly _instantiationService: IInstantiationService,
 		@IEditorGroupsService
 		private readonly _editorGroupsService: IEditorGroupsService,
+		@ICommandService private readonly _commandService: ICommandService,
 	) {
 		super(
 			PearOverlayPart.ID,
@@ -305,6 +307,8 @@ export class PearOverlayPart extends Part {
 		}
 		this.state = "open";
 		this.fullScreenOverlay!.style.zIndex = "95";
+
+		this._commandService.executeCommand('pearai.notifyOverlayOpened');
 
 		const container = this.webviewView!.webview.container;
 		container.style.display = "flex";


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Executes `pearai.notifyOverlayOpened` command when `PearOverlayPart` is opened, adding `ICommandService` dependency.
> 
>   - **Behavior**:
>     - Executes `pearai.notifyOverlayOpened` command in `open()` method of `PearOverlayPart`.
>   - **Dependencies**:
>     - Adds `ICommandService` to `PearOverlayPart` constructor.
>   - **Imports**:
>     - Adds import for `ICommandService` in `pearOverlayPart.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 872a83c75e8a22305259abf2788d5325803043a1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->