### PR TITLE
settings button

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -1606,3 +1606,25 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 		quickPick.show();
 	}
 });
+
+registerAction2(class PearAISettingsAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.pearaiSettings',
+			title: localize2('pearaiSettings', "PearAI Settings"),
+			f1: true,
+			icon: Codicon.settingsGear,
+			menu: [
+				{
+					id: MenuId.LayoutControlMenu,
+					group: '0_Actions'
+				}
+			]
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const commandService = accessor.get(ICommandService);
+		commandService.executeCommand("pearai.toggleOverlay")
+	}
+});

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -652,7 +652,8 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				if (isAccountsActionVisible(this.storageService)) {
 					actions.primary.push(ACCOUNTS_ACTIVITY_TILE_ACTION);
 				}
-				actions.primary.push(GLOBAL_ACTIVITY_TITLE_ACTION);
+				// this is settings icon, replaced by pearai settings icon in layout actions.
+				// actions.primary.push(GLOBAL_ACTIVITY_TITLE_ACTION);
 			}
 
 			// --- Layout Actions


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add PearAI settings action and replace global activity title action in title bar.
> 
>   - **Behavior**:
>     - Adds `PearAISettingsAction` in `layoutActions.ts` to toggle PearAI overlay via `pearai.toggleOverlay` command.
>     - Removes `GLOBAL_ACTIVITY_TITLE_ACTION` from primary actions in `titlebarPart.ts`.
>   - **UI**:
>     - Registers `PearAISettingsAction` with `Codicon.settingsGear` icon in `LayoutControlMenu` under `0_Actions` group.
>   - **Misc**:
>     - Comments out `GLOBAL_ACTIVITY_TITLE_ACTION` in `titlebarPart.ts` to replace it with PearAI settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 2682de5f593586b945df942c5234523473177c27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->