### PR TITLE
Upgrade setup script and contributing docs for Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,10 @@ Ensure you have the following tools installed:
 - 📦 [Yarn 1](https://classic.yarnpkg.com/en/), version `>=1.10.1 and <2`
 - 🐍 [Python](https://www.python.org/downloads/), version `=3.11.X` (required for node-gyp)
 - ⚙️ A C/C++ compiler toolchain for your platform:
-  - **Windows**: Install the Windows Build Tools and follow the detailed setup steps.
+  - **Windows**: Install the Windows Build Tools (through Visual Studio Installer) with the following components
+    - Desktop development with C++ (Workload)
+    - C++ MFC for v143 build tools with Spectre Mitigations (Individual Component)
+    - MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (Individual Component)
   - **macOS**: Install Xcode and Command Line Tools with `xcode-select --install`.
   - **Linux**: Install the necessary development tools as described in the instructions.
 

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -43,7 +43,7 @@ function Initialize-BaseFunctionality {
     Set-Location $currentDir
 
     Write-Host "`nSetting up root application..." -ForegroundColor White
-    Invoke-CMD -Command "yarn install" -ErrorMessage "Failed to install dependencies with yarn"
+    Invoke-CMD -Command "npm install" -ErrorMessage "Failed to install dependencies with yarn"
 }
 
 function Create-SymLink {

--- a/scripts/pearai/setup-environment.ps1
+++ b/scripts/pearai/setup-environment.ps1
@@ -43,7 +43,7 @@ function Initialize-BaseFunctionality {
     Set-Location $currentDir
 
     Write-Host "`nSetting up root application..." -ForegroundColor White
-    Invoke-CMD -Command "npm install" -ErrorMessage "Failed to install dependencies with yarn"
+    Invoke-CMD -Command "npm install" -ErrorMessage "Failed to install dependencies with npm"
 }
 
 function Create-SymLink {


### PR DESCRIPTION
Updating some docs around setting up for Windows. `yarn.lock` file seems broken for install, and we need a couple other specific build tools in order to correctly update `node-gyp`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Windows setup script to use `npm` instead of `yarn` and enhance contributing docs with additional Windows build tool requirements.
> 
>   - **Setup Script**:
>     - In `setup-environment.ps1`, change `yarn install` to `npm install` for dependency installation.
>   - **Documentation**:
>     - Update `CONTRIBUTING.md` to specify additional Windows build tools required: Desktop development with C++, C++ MFC for v143 build tools with Spectre Mitigations, and MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for bedc7ae273745619a601c00c9153b52a6c43776c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->