### PR TITLE
bubbly progress

### DIFF
--- a/extensions/theme-defaults/themes/pearai_light.json
+++ b/extensions/theme-defaults/themes/pearai_light.json
@@ -60,6 +60,7 @@
 		"list.activeSelectionBackground": "#E8E8E8",
 		"list.activeSelectionForeground": "#000000",
 		"list.activeSelectionIconForeground": "#000000",
+		"list.highlightForeground": "#d7d7d7",
 		"list.hoverBackground": "#F2F2F2",
 		"list.focusAndSelectionOutline": "#000000",
 		"menu.border": "#CECECE",

--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -15,6 +15,7 @@
 	height: 100%;
 	width: 100%;
 	align-items: center;
+	/* border: 1px solid red; */
 }
 
 .monaco-action-bar.vertical .actions-container {

--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -135,7 +135,6 @@
 	width: 100%;
 	opacity: 1 !important; /* Settings editor uses opacity < 1 */
 	overflow: hidden;
-
 	/* Backup color in case the tree does not provide the background color */
 	background-color: var(--vscode-sideBar-background);
 }

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -89,7 +89,7 @@
 
 .monaco-workbench.hc-black .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before,
 .monaco-workbench.hc-black .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus .active-item-indicator:before {
-	border-color: var(--vscode-activityBar-activeBorder);
+	/* border-color: var(--vscode-activityBar-activeBorder); */
 }
 
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before {

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -5,6 +5,16 @@
 
 /* Container */
 
+.monaco-workbench .part.editor > .content {
+	position: absolute;
+	box-sizing: border-box;
+	width: 100%;
+	height: 100%;
+	margin: 8px;
+	border: 1px solid red;
+	border-radius: 8px;
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container {
 	height: 100%;
 }
@@ -345,8 +355,9 @@
 }
 
 .monaco-workbench .part.editor > .content .grid-view-container {
-	width: 100%;
-	height: 100%;
+	width: calc(100% - 16px);
+	height: calc(100% - 16px);
+	margin: 8px;
 }
 
 /* Hide no-workspace watermark when not needed */

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -44,6 +44,7 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
 	display: flex;
 	position: relative; /* position tabs border bottom or editor actions (when tabs wrap) relative to this container */
+
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.empty {
@@ -77,6 +78,9 @@
 	display: flex;
 	height: var(--editor-group-tab-height);
 	scrollbar-width: none; /* Firefox: hide scrollbar */
+	padding: 6px;
+	background-color: var(--vscode-tab-unfocusedActiveBackground);
+	gap: 6px;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.scroll {
@@ -104,16 +108,19 @@
 	height: var(--editor-group-tab-height);
 	box-sizing: border-box;
 	padding-left: 10px;
+	border-right: none;
 }
 
 /* Tab Background Color in/active group/tab */
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
+	border-radius: 8px;
 	background-color: var(--vscode-tab-unfocusedInactiveBackground);
 }
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab {
 	background-color: var(--vscode-tab-inactiveBackground);
 }
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
+	border: 1.5px solid var(--vscode-tab-unfocusedInactiveBackground);
 	background-color: var(--vscode-tab-unfocusedActiveBackground);
 }
 .monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1726,9 +1726,9 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		const showLastStickyTabBorderColor = this.tabsModel.stickyCount !== this.tabsModel.count;
 
 		// Borders / Outline
-		const borderRightColor = ((isTabLastSticky && showLastStickyTabBorderColor ? this.getColor(TAB_LAST_PINNED_BORDER) : undefined) || this.getColor(TAB_BORDER) || this.getColor(contrastBorder));
-		tabContainer.style.borderRight = borderRightColor ? `1px solid ${borderRightColor}` : '';
-		tabContainer.style.outlineColor = this.getColor(activeContrastBorder) || '';
+		// const borderRightColor = ((isTabLastSticky && showLastStickyTabBorderColor ? this.getColor(TAB_LAST_PINNED_BORDER) : undefined) || this.getColor(TAB_BORDER) || this.getColor(contrastBorder));
+		// tabContainer.style.borderRight = borderRightColor ? `1px solid ${borderRightColor}` : '';
+		// tabContainer.style.outlineColor = this.getColor(activeContrastBorder) || '';
 	}
 
 	protected override prepareEditorActions(editorActions: IToolbarActions): IToolbarActions {

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -15,11 +15,13 @@
 
 .monaco-workbench.nomaineditorarea .part.panel.bottom .composite.title {
 	border-top-width: 0; /* no border when main editor area is hiden */
+	border: 1px solid red;
 }
 
 .monaco-workbench .part.panel.top {
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
+	border: 1px solid blue;
 }
 
 .monaco-workbench.nomaineditorarea .part.panel.top {
@@ -65,6 +67,45 @@
 .monaco-workbench .part.panel > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item:focus .action-label,
 .monaco-workbench .part.panel > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item:hover .action-label {
 	color: var(--vscode-panelTitle-activeForeground) !important;
+}
+
+.monaco-workbench .part.panel > .title > .composite-bar-container >.composite-bar > .monaco-action-bar {
+	line-height: 18px;
+	height: 24px;
+}
+
+.monaco-workbench .part.panel > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .actions-container {
+	margin-top: 8px;
+	/* border: 1px solid red; */
+}
+
+.monaco-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked {
+	background-color: var(--vscode-list-highlightForeground);
+	border-radius: 8px;
+	border: none !important;
+	/* border: 1px solid rgb(13, 255, 0); */
+}
+
+.monaco-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked > .action-label {
+	border: none !important;
+}
+
+.monaco-workbench .part.panel > .title > .title-actions > .monaco-toolbar > .monaco-action-bar > .actions-container {
+	/* height: auto; */
+	height: 24px;
+	border-radius: 8px 0px 0px 8px;
+	background-color: var(--vscode-list-highlightForeground);
+	/* border: 1px solid red; */
+	margin-top: 8px;
+}
+.monaco-workbench .part.panel > .title > .global-actions > .monaco-toolbar > .monaco-action-bar > .actions-container {
+	/* height: auto; */
+	height: 24px;
+	border-radius: 8px;
+	border-radius: 0px 8px 8px 0px;
+	background-color: var(--vscode-list-highlightForeground);
+	/* border: 1px solid red; */
+	margin-top: 8px;
 }
 
 .monaco-workbench .part.panel .monaco-inputbox {

--- a/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
+++ b/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
@@ -85,7 +85,7 @@
 .monaco-workbench .part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before,
 .monaco-workbench .part.sidebar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked:not(:focus) .active-item-indicator:before,
 .monaco-workbench .part.sidebar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked.clicked:focus .active-item-indicator:before {
-	border-top-color: var(--vscode-activityBarTop-activeBorder) !important;
+	/* border-top-color: var(--vscode-activityBarTop-activeBorder) !important; */
 }
 
 .monaco-workbench .part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,

--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -266,6 +266,8 @@
 	height: 24px;
 	font-size: 12px;
 	flex: 1;
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 8px;
 }
 
 .pane-header .viewpane-filter-container > .viewpane-filter .monaco-inputbox .monaco-inputbox {

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -384,7 +384,7 @@
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label.checked {
-	border-bottom: 1px solid var(--vscode-panelTitle-activeBorder);
+	border-bottom: 5px solid var(--vscode-panelTitle-activeBorder);
 	color: var(--vscode-panelTitle-activeForeground);
 }
 

--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -7,10 +7,12 @@
 .explorer-folders-view,
 .explorer-folders-view {
 	height: 100%;
+	padding: 0 8px;
 }
 
 .explorer-folders-view .monaco-list-row {
-	padding-left: 4px; /* align top level twistie with `Explorer` title label */
+	padding-left: 0px; /* align top level twistie with `Explorer` title label */
+	border-radius: 4px;
 }
 
 .explorer-folders-view .explorer-folders-view.highlight .monaco-list .explorer-item:not(.explorer-item-edited),
@@ -76,7 +78,7 @@
 }
 
 .explorer-folders-view .explorer-item .monaco-icon-name-container.multiple > .label-name.drop-target > .monaco-highlighted-label {
-	background-color: var(--vscode-list-dropBackground);
+	background-color: red;
 }
 
 .explorer-folders-view .explorer-item.align-nest-icon-with-parent-icon {
@@ -110,3 +112,10 @@
 .monaco-workbench.context-menu-visible .explorer-folders-view.highlight .monaco-list-row {
 	outline: none !important;
 }
+
+/* Override hover background color for explorer rows
+.explorer-folders-view .monaco-list-row:hover:not(.selected):not(.focused) {
+	border: 1px solid red;
+	background-color: red !important;
+}
+ */

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -295,7 +295,7 @@
 .monaco-workbench .inline-chat .status .monaco-toolbar .action-label.checked {
 	color: var(--vscode-inputOption-activeForeground);
 	background-color: var(--vscode-inputOption-activeBackground);
-	outline: 1px solid var(--vscode-inputOption-activeBorder);
+	outline: 4px solid var(--vscode-inputOption-activeBorder);
 }
 
 

--- a/src/vs/workbench/contrib/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/preferences.css
@@ -108,9 +108,9 @@
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked,
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label:hover {
 	color: var(--vscode-panelTitle-activeForeground);
-	border-bottom: 1px solid var(--vscode-panelTitle-activeBorder);
-	outline: 1px solid var(--vscode-contrastActiveBorder, transparent);
-	outline-offset: -1px;
+	border-bottom: 3px solid var(--vscode-panelTitle-activeBorder);
+	outline: 3px solid var(--vscode-contrastActiveBorder, transparent);
+	outline-offset: 3px;
 }
 
 .settings-tabs-widget > .monaco-action-bar .action-item .action-label:focus {

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -130,7 +130,7 @@
 
 .settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item .action-label:not(.checked):not(:focus) {
 	/* Still maintain a border for alignment, but keep it transparent */
-	border-bottom: 1px solid transparent;
+	border-bottom: 5px solid transparent;
 }
 
 .settings-editor > .settings-body {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This pull request updates CSS styling across various components, adding borders, adjusting padding, and modifying colors, with some changes commented out for potential future use.
> 
>   - **CSS Styling Adjustments**:
>     - Added `border: 1px solid red` to `.monaco-workbench .part.editor > .content` in `editorgroupview.css`.
>     - Added `border: 1px solid blue` to `.monaco-workbench .part.panel.top` in `panelpart.css`.
>     - Added `border-radius: 8px` to `.monaco-workbench .part.panel > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked` in `panelpart.css`.
>     - Added `border-bottom: 5px solid var(--vscode-panelTitle-activeBorder)` to `.extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label.checked` in `extensionEditor.css`.
>     - Added `border-bottom: 3px solid var(--vscode-panelTitle-activeBorder)` to `.settings-tabs-widget > .monaco-action-bar .action-item .action-label.checked` in `preferences.css`.
>     - Added `border-bottom: 5px solid transparent` to `.settings-editor > .settings-header > .settings-header-controls .settings-tabs-widget > .monaco-action-bar .action-item .action-label:not(.checked):not(:focus)` in `settingsEditor2.css`.
>   - **Commented Out Code**:
>     - Commented out `border-color` in `.monaco-workbench.hc-black .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before` in `activityaction.css`.
>     - Commented out `border: 1px solid red` in `.monaco-workbench .part.panel > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .actions-container` in `panelpart.css`.
>     - Commented out `border: 1px solid red` in `.explorer-folders-view .monaco-list-row:hover:not(.selected):not(.focused)` in `explorerviewlet.css`.
>   - **Miscellaneous**:
>     - Added `padding: 0 8px` to `.explorer-folders-view` in `explorerviewlet.css`.
>     - Added `border-radius: 4px` to `.explorer-folders-view .monaco-list-row` in `explorerviewlet.css`.
>     - Added `border: 1px solid rgba(255, 255, 255, 0.1)` to `.viewpane-filter-container > .viewpane-filter .monaco-inputbox` in `views.css`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 8a1afe691f78e330106680ede066fe341654697b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->