### PR TITLE
Decouple PearAI Toolbar from Activity Bar

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -17,7 +17,7 @@ import { ActiveAuxiliaryContext, AuxiliaryBarFocusContext } from '../../../commo
 import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_TOP_ACTIVE_BORDER, ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_TOP_FOREGROUND, ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND, PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_DRAG_AND_DROP_BORDER, PANEL_INACTIVE_TITLE_FOREGROUND, SIDE_BAR_BACKGROUND, SIDE_BAR_BORDER, SIDE_BAR_TITLE_BORDER, SIDE_BAR_FOREGROUND } from '../../../common/theme.js';
 import { IViewDescriptorService } from '../../../common/views.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { ActivityBarPosition, IWorkbenchLayoutService, LayoutSettings, Parts, Position } from '../../../services/layout/browser/layoutService.js';
+import { IWorkbenchLayoutService, Parts, Position } from '../../../services/layout/browser/layoutService.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IAction, Separator, SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { ToggleAuxiliaryBarAction } from './auxiliaryBarActions.js';
@@ -29,7 +29,6 @@ import { AbstractPaneCompositePart, CompositeBarPosition } from '../paneComposit
 import { ActionsOrientation, IActionViewItem, prepareActions } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IPaneCompositeBarOptions } from '../paneCompositeBar.js';
 import { IMenuService, MenuId } from '../../../../platform/actions/common/actions.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { getContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { $ } from '../../../../base/browser/dom.js';
 import { HiddenItemStrategy, WorkbenchToolBar } from '../../../../platform/actions/browser/toolbar.js';
@@ -87,7 +86,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		@IExtensionService extensionService: IExtensionService,
 		@ICommandService commandService: ICommandService,
 		@IMenuService menuService: IMenuService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(
 
@@ -117,22 +115,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			menuService,
 			commandService
 		);
-
-
-		this._register(configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION)) {
-				this.onDidChangeActivityBarLocation();
-			}
-		}));
-	}
-
-	private onDidChangeActivityBarLocation(): void {
-		this.updateCompositeBar();
-
-		const id = this.getActiveComposite()?.getId();
-		if (id) {
-			this.onTitleAreaUpdate(id);
-		}
 	}
 
 	override updateStyles(): void {
@@ -210,7 +192,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	}
 
 	protected shouldShowCompositeBar(): boolean {
-		return this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION) !== ActivityBarPosition.HIDDEN;
+		return true;
 	}
 
 	// TODO@benibenj chache this


### PR DESCRIPTION
Closes https://github.com/trypear/pearai-app/issues/235

Currently the PearAI Toolbar seems to stack when toggling the "Activity Bar" from Command Palette. The reason behind this is because `shouldShowCompositeBar()` method in `auxiliaryBarParts.ts` is coupled with how the activity bar appears and disappears. Since we want the PearAI Toolbar to always display regardless of Activity Bar position/visibility, we should just always return true for that method, similar to how[ we do in `panelPart.ts` ](https://github.com/trypear/pearai-app/blob/main/src/vs/workbench/browser/parts/panel/panelPart.ts#L211-L213)

**Manual Testing**
I did some testing around switching the Activity Bar positions and toggling visibility, as well as moving the PearAI Sidebar to the left/right and toggling as well. For these tests, the Activity Bar will toggle between visible and hidden, but the PearAI Toolbar stays consistent in its location

https://github.com/user-attachments/assets/47b9d50d-4a26-4b4b-959a-24fe9e013409


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Decouples PearAI Toolbar from Activity Bar by always showing the toolbar in `auxiliaryBarPart.ts`.
> 
>   - **Behavior**:
>     - `shouldShowCompositeBar()` in `auxiliaryBarPart.ts` now always returns `true`, ensuring PearAI Toolbar visibility regardless of Activity Bar state.
>   - **Code Cleanup**:
>     - Removed `ActivityBarPosition` and `IConfigurationService` imports from `auxiliaryBarPart.ts`.
>     - Removed `onDidChangeActivityBarLocation()` method and its registration in `auxiliaryBarPart.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for e2e638c9bd524a2a9100c260d5851ccd791a9271. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->