### PR TITLE
Bubbly UI

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
 	"nameShort": "PearAI",
 	"nameLong": "PearAI",
-	"pearAIVersion": "1.8.8",
+	"pearAIVersion": "1.8.9",
 	"applicationName": "PearAI",
 	"dataFolderName": ".pearai",
 	"win32MutexName": "pearai",

--- a/product.json
+++ b/product.json
@@ -1,7 +1,7 @@
 {
 	"nameShort": "PearAI",
 	"nameLong": "PearAI",
-	"pearAIVersion": "1.8.7",
+	"pearAIVersion": "1.8.8",
 	"applicationName": "PearAI",
 	"dataFolderName": ".pearai",
 	"win32MutexName": "pearai",

--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -47,7 +47,7 @@ export interface IPaneStyles {
  */
 export abstract class Pane extends Disposable implements IView {
 
-	private static readonly HEADER_SIZE = 22;
+	private static readonly HEADER_SIZE = 26;
 
 	readonly element: HTMLElement;
 	private header!: HTMLElement;

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,14 +1,14 @@
 /* Bubbly parts */
 .bubbly-part {
 	box-sizing: border-box;
+	--bubbly-radius-s: 4px;
+	--bubbly-radius-base: 6px;/* The main radius - used on most elements */
+	--bubbly-radius-l: 8px;
+	--bubbly-radius-xl: 10px;/* Used for radius on bubbly part containers */
 }
 
 .bubbly-part-pad {
 	margin: 5px;
-}
-
-.bubbly-part-round {
-	border-radius: 12px;
 }
 
 .split-view-view:has(> .bubbly-part) {
@@ -16,13 +16,13 @@
 }
 
 .bubbly-part .bubbly-editor-content {
-	border-radius: 10px;
+	border-radius: var(--bubbly-radius-xl);
 	box-sizing: border-box;
 }
 
 /* Base UI elements */
 .monaco-inputbox {
-	border-radius: 6px;
+	border-radius: var(--bubbly-radius-base);
 }
 
 /* Globally, pane titles won't be forced uppercase */
@@ -36,13 +36,19 @@
 	border-bottom-color: transparent !important;
 }
 
+.bubbly-part.part.panel .action-item > .active-item-indicator::before {
+	border-top-width: 0 !important;
+}
+
 .bubbly-part.part.panel .action-item {
 	background-color: var(--vscode-toolbar-hoverBackground);
-	border-radius: 8px;
-	padding: 2px;
+	border-radius: var(--bubbly-radius-base);
+	/*padding: 2px;*/
 	box-sizing: border-box;
 	height: 80% !important;
 	transition: background-color 0.05s linear;
+	display: flex;
+	align-items: center;
 }
 
 .bubbly-part.part.panel .composite-bar-container .action-item {
@@ -102,41 +108,38 @@
 
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
 	align-items: center;
-	gap: 3px;
+	gap: 3px;/* this adds a gap between the left side and right side when there are many editors open */
 }
 
+/* The container which holds the tabs and action bar thing on the right side */
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container {
 	height: calc(var(--editor-group-tab-height) + var(--editor-group-tab-padding) * 2);
 	align-items: center;
-	margin-left: 4px;
-	margin-right: 4px;
-	padding-left: 4px;
-	padding-right: 4px;
+	margin-left: 8px;
+	margin-right: 2px;
+	gap: 4px;
 }
 
+/* This is each file tab */
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab {
-	border-radius: 10px;
-	margin-left: 3px;
-	margin-right: 3px;
+	border-radius: var(--bubbly-radius-xl);
 	align-items: center;
 	border: 1px solid transparent !important;
 }
 
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-unfocusedActiveBackground);
-	border: 1px solid var(--tab-border-top-color, transparent) !important;
-	/*border: 1px solid var(--vscode-tab-selectedForeground, transparent) !important;*/
+	border: 1px solid var(--vscode-tab-inactiveForeground, transparent) !important;
 }
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	background: transparent;
-	/*box-shadow: 0px 0px 3px 1px var(--tab-border-top-color)*/
 }
 
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .editor-actions {
 	padding-left: 6px;
 	padding-right: 6px;
 	gap: 3px;
-	border-radius: 6px;
+	border-radius: var(--bubbly-radius-base);
 	background: var(--vscode-editorGroupHeader-tabsBackground);
 	margin-right: 8px;
 }
@@ -173,7 +176,8 @@
 }
 
 .bubbly-part.sidebar .composite.title {
-	height: 28px;
+	/*height: 28px;*/
+	align-items: center;
 }
 
 .bubbly-part.sidebar .composite.title > .title-label > h2 {
@@ -193,8 +197,12 @@
 	font-size: 13.5px;
 }
 
-.bubbly-part.sidebar .scrollbar > .slider {
-	border-radius: 4px;
+.bubbly-part/*.sidebar*/ .scrollbar > .slider {
+	border-radius: var(--bubbly-radius-base);
+}
+
+.bubbly-part.sidebar .monaco-list-row {
+	border-radius: var(--bubbly-radius-l);
 }
 
 /* Styles - Activity bar (when on sidebar)*/
@@ -202,13 +210,14 @@
 	gap: 2px;
 }
 
+/* This is each little icon on the top of the sidebar */
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
 	width: 22px;
 	height: 26px;
 	align-items: center;
 	justify-content: center;
 	padding: 2px;
-	border-radius: 6px;
+	border-radius: var(--bubbly-radius-base);
 }
 
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
@@ -253,7 +262,7 @@
 
 .bubbly-part.activitybar .action-item .action-label.codicon {
 	font-size: 20px !important;
-	border-radius: 8px;
+	border-radius: var(--bubbly-radius-l);
 	border: 1px solid transparent;
 	overflow: visible !important;
 	box-sizing: border-box;

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -25,17 +25,36 @@
 	border-radius: 6px;
 }
 
-/* Styles - Panel (bottom bar) */
-.bubbly-part .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
+/* Globally, pane titles won't be forced uppercase */
+.monaco-pane-view .pane > .pane-header > .title {
 	text-transform: none !important;
 }
 
+/* Styles - Panel (bottom bar) */
+.bubbly-part.part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
+	text-transform: none !important;
+	border-bottom-color: transparent !important;
+}
+
 .bubbly-part.part.panel .action-item {
-	background: var(--vscode-toolbar-hoverBackground);
+	background-color: var(--vscode-toolbar-hoverBackground);
 	border-radius: 8px;
 	padding: 2px;
 	box-sizing: border-box;
 	height: 80% !important;
+	transition: background-color 0.05s linear;
+}
+
+.bubbly-part.part.panel .composite-bar-container .action-item {
+	background-color: transparent;
+}
+
+.bubbly-part.part.panel .action-item:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.bubbly-part.part.panel .action-item.checked {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .bubbly-part.part.panel .actions-container {
@@ -73,6 +92,7 @@
 .monaco-split-view2 > .sash-container > .monaco-sash {
 	color: transparent;
 	background: transparent;
+	--vscode-sash-hoverBorder: var(--vscode-charts-blue);
 }
 
 /* Styles - Editor: tabs/files */
@@ -152,6 +172,31 @@
 	border: none !important;
 }
 
+.bubbly-part.sidebar .composite.title {
+	height: 28px;
+}
+
+.bubbly-part.sidebar .composite.title > .title-label > h2 {
+	line-height: 28px;
+	font-size: 11.5px;
+	font-weight: 700;
+	text-transform: none;
+}
+
+.bubbly-part.sidebar .composite.title .title-actions {
+	height: 25px;
+}
+
+/* Explorer */
+.bubbly-part.sidebar .monaco-highlighted-label {
+	font-weight: 500;
+	font-size: 13.5px;
+}
+
+.bubbly-part.sidebar .scrollbar > .slider {
+	border-radius: 4px;
+}
+
 /* Styles - Activity bar (when on sidebar)*/
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
 	gap: 2px;
@@ -182,6 +227,7 @@
 
 /* Styles - Activity bar (when on left side of screen, detached from sidebar) */
 .monaco-workbench .bubbly-part.part.activitybar {
+	background-color: transparent !important;
 	color: transparent !important;
 }
 
@@ -239,4 +285,8 @@
 
 .part.auxiliarybar {
 	border-left: none !important;
+}
+
+.part.titlebar {
+	border-bottom: none !important;
 }

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,3 +1,4 @@
+/* Base - bubbly parts */
 .bubbly-part {
 	border-radius: 12px;
 	box-sizing: border-box;
@@ -13,8 +14,7 @@
 	box-sizing: border-box;
 }
 
-/* Panel styling */
-
+/* Panel (bottom bar) */
 .bubbly-part .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
 	text-transform: none !important;
 }
@@ -43,6 +43,20 @@
 	background: var(--vscode-toolbar-hoverBackground) !important;
 }
 
+.bubbly-part.part.panel {
+	background: var(--vscode-editor-background) !important;
+	--vscode-panel-background: var(--vscode-editor-background);
+}
+
+/* Style the terminal to be the same color as panel*/
+.bubbly-part .terminal .xterm-scrollable-element {
+	background-color: var(--vscode-editor-background) !important;
+}
+
+.bubbly-part .terminal-wrapper {
+	background: var(--vscode-editor-background);
+}
+
 /* Sash */
 /* Globally, we will hide the sash */
 .monaco-split-view2 > .sash-container > .monaco-sash {
@@ -50,8 +64,7 @@
 	background: transparent;
 }
 
-/* Editor tabs/files */
-
+/* Editor - tabs/files */
 .bubbly-part .bubbly-editor-parent {
 	background: var(--vscode-editorGroupHeader-tabsBackground);
 }

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -136,6 +136,7 @@
 
 .bubbly-part.panel .composite.title {
 	padding: 8px;
+	padding-right: 12px;
 	height: 51px;/* updated title size to account for padding, see layoutService.ts*/
 }
 

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -5,6 +5,7 @@
 	--bubbly-radius-base: 6px;/* The main radius - used on most elements */
 	--bubbly-radius-l: 8px;
 	--bubbly-radius-xl: 10px;/* Used for radius on bubbly part containers */
+	--bubbly-text-transform: none;
 }
 
 .bubbly-part-pad {
@@ -27,12 +28,12 @@
 
 /* Globally, pane titles won't be forced uppercase */
 .monaco-pane-view .pane > .pane-header > .title {
-	text-transform: none !important;
+	text-transform: var(--bubbly-text-transform) !important;
 }
 
 /* Styles - Panel (bottom bar) */
 .bubbly-part.part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
-	text-transform: none !important;
+	text-transform: var(--bubbly-text-transform) !important;
 	border-bottom-color: transparent !important;
 }
 
@@ -75,6 +76,11 @@
 	justify-content: center;
 }
 
+.bubbly-part .monaco-select-box {
+	border: none !important;
+	border-color: transparent !important;
+}
+
 .bubbly-part .action-item .monaco-select-box, .action-item .monaco-inputbox {
 	background: var(--vscode-toolbar-hoverBackground) !important;
 }
@@ -82,6 +88,10 @@
 .bubbly-part.part.panel {
 	background: var(--vscode-editor-background) !important;
 	--vscode-panel-background: var(--vscode-editor-background);
+}
+
+.bubbly-part.part.panel .composite.title {
+	margin-top: 2px;
 }
 
 /* Terminal - style the terminal to be the same color as panel*/
@@ -120,6 +130,14 @@
 	gap: 4px;
 }
 
+.bubbly-part.part.editor .actions-container {
+	gap: 6px;
+}
+
+.bubbly-part.part.editor .actions-container .action-item {
+	margin-right: 0 !important;
+}
+
 /* This is each file tab */
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab {
 	border-radius: var(--bubbly-radius-xl);
@@ -128,8 +146,7 @@
 }
 
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
-	background-color: var(--vscode-tab-unfocusedActiveBackground);
-	border: 1px solid var(--vscode-tab-inactiveForeground, transparent) !important;
+	border: 0.5px solid var(--vscode-tab-unfocusedInactiveForeground, transparent) !important;
 }
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	background: transparent;
@@ -184,17 +201,21 @@
 	line-height: 28px;
 	font-size: 11.5px;
 	font-weight: 700;
-	text-transform: none;
+	text-transform: var(--bubbly-text-transform);
 }
 
 .bubbly-part.sidebar .composite.title .title-actions {
 	height: 25px;
 }
 
+.bubbly-part.sidebar .pane-header {
+	height: 26px;
+}
+
 /* Explorer */
 .bubbly-part.sidebar .monaco-highlighted-label {
 	font-weight: 500;
-	font-size: 13.5px;
+	font-size: 13px;/* was 13 */
 }
 
 .bubbly-part/*.sidebar*/ .scrollbar > .slider {
@@ -202,7 +223,7 @@
 }
 
 .bubbly-part.sidebar .monaco-list-row {
-	border-radius: var(--bubbly-radius-l);
+	border-radius: var(--bubbly-radius-s);
 }
 
 /* Styles - Activity bar (when on sidebar)*/
@@ -212,8 +233,8 @@
 
 /* This is each little icon on the top of the sidebar */
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
-	width: 22px;
-	height: 26px;
+	width: 28px;
+	height: 30px;
 	align-items: center;
 	justify-content: center;
 	padding: 2px;
@@ -234,6 +255,16 @@
 	position: relative;
 }
 
+.bubbly-part.sidebar .composite.header {
+	height: 42px;
+	align-items: center;
+}
+
+.bubbly-part.sidebar .composite.header .action-item {
+	height: 30px !important;
+	width: 30px !important;
+}
+
 /* Styles - Activity bar (when on left side of screen, detached from sidebar) */
 .monaco-workbench .bubbly-part.part.activitybar {
 	background-color: transparent !important;
@@ -248,31 +279,30 @@
 	display: flex;
 	gap: 1px;
 	flex-direction: column;
-	margin-top: 5px;
-	margin-bottom: 5px;
+	margin-top: 8px;
+	margin-bottom: 6px;
 }
 
 .bubbly-part.activitybar .action-item {
 	box-sizing: border-box;
 	align-items: center;
 	justify-content: center;
-	width: 48px;
-	height: 48px;
+	width: 40px;
+	height: 40px;
 }
 
 .bubbly-part.activitybar .action-item .action-label.codicon {
-	font-size: 20px !important;
+	font-size: 18px !important;
 	border-radius: var(--bubbly-radius-l);
 	border: 1px solid transparent;
 	overflow: visible !important;
 	box-sizing: border-box;
-	width: 40px !important;
-	height: 40px !important;
+	width: 32px !important;
+	height: 32px !important;
 }
 
 .bubbly-part.activitybar .action-item.checked .action-label.codicon {
 	background: var(--vscode-toolbar-hoverBackground) !important;
-	border: 1px solid var(--insert-border-color);
 }
 
 .bubbly-part.activitybar .active-item-indicator::before {

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -8,7 +8,7 @@
 	--bubbly-radius-base: 6px;/* The main radius - used on most elements */
 	--bubbly-radius-l: 8px;
 	--bubbly-radius-xl: 10px;/* Used for radius on bubbly part containers */
-	--bubbly-text-transform: none;
+	--bubbly-text-transform: uppercase;
 }
 
 .bubbly-part-pad {
@@ -90,7 +90,6 @@
 .bubbly-part.panel .composite-bar-container .action-item {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	border-radius: var(--bubbly-radius-base);
-	/*padding: 2px;*/
 	box-sizing: border-box;
 	height: 80% !important;
 	transition: background-color 0.05s linear;
@@ -260,7 +259,6 @@
 .bubbly-part.sidebar > .composite.title > .title-label > h2 {
 	line-height: 28px;
 	font-size: 11.5px;
-	font-weight: 700;
 	text-transform: var(--bubbly-text-transform);
 }
 
@@ -270,12 +268,6 @@
 
 .bubbly-part.sidebar .pane-header {
 	height: 26px;
-}
-
-/* Explorer */
-.part.sidebar .monaco-highlighted-label {
-	font-weight: 500;
-	font-size: 13px;/* was 13 */
 }
 
 /* Activity bar (when on sidebar) */

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,8 +1,14 @@
 /* Base - bubbly parts */
 .bubbly-part {
-	border-radius: 12px;
 	box-sizing: border-box;
+}
+
+.bubbly-part-pad {
 	margin: 5px;
+}
+
+.bubbly-part-round {
+	border-radius: 12px;
 }
 
 .split-view-view:has(> .bubbly-part) {
@@ -14,7 +20,7 @@
 	box-sizing: border-box;
 }
 
-/* Panel (bottom bar) */
+/* Styles - Panel (bottom bar) */
 .bubbly-part .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
 	text-transform: none !important;
 }
@@ -48,7 +54,7 @@
 	--vscode-panel-background: var(--vscode-editor-background);
 }
 
-/* Style the terminal to be the same color as panel*/
+/* Terminal - style the terminal to be the same color as panel*/
 .bubbly-part .terminal .xterm-scrollable-element {
 	background-color: var(--vscode-editor-background) !important;
 }
@@ -57,14 +63,14 @@
 	background: var(--vscode-editor-background);
 }
 
-/* Sash */
+/* Styles - Sash */
 /* Globally, we will hide the sash */
 .monaco-split-view2 > .sash-container > .monaco-sash {
 	color: transparent;
 	background: transparent;
 }
 
-/* Editor - tabs/files */
+/* Styles - Editor: tabs/files */
 .bubbly-part .bubbly-editor-parent {
 	background: var(--vscode-editorGroupHeader-tabsBackground);
 }
@@ -94,6 +100,7 @@
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 	background-color: var(--vscode-tab-unfocusedActiveBackground);
 	border: 1px solid var(--tab-border-top-color, transparent) !important;
+	/*border: 1px solid var(--vscode-tab-selectedForeground, transparent) !important;*/
 }
 .monaco-workbench .bubbly-part.part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
 	background: transparent;
@@ -126,7 +133,7 @@
 	border-right: none !important;
 }
 
-/* Sidebar stylings */
+/* Styles - Sidebar */
 
 .bubbly-part .pane-header {
 	background-color: transparent !important;
@@ -140,6 +147,7 @@
 	border: none !important;
 }
 
+/* Styles - Activity bar (when on sidebar)*/
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
 	gap: 2px;
 }
@@ -166,4 +174,54 @@
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
 	left: 0;
 	position: relative;
+}
+
+/* Styles - Activity bar (when on left side of screen, detached from sidebar) */
+.monaco-workbench .bubbly-part.part.activitybar {
+	color: transparent !important;
+}
+
+.monaco-workbench .part.activitybar {/* Updated in code, see activitybarPart.ts */
+	width: 56px;
+}
+
+.bubbly-part.activitybar .actions-container {
+	display: flex;
+	gap: 1px;
+	flex-direction: column;
+	margin-top: 5px;
+	margin-bottom: 5px;
+}
+
+.bubbly-part.activitybar .action-item {
+	box-sizing: border-box;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+}
+
+.bubbly-part.activitybar .action-item .action-label.codicon {
+	font-size: 20px !important;
+	border-radius: 8px;
+	border: 1px solid transparent;
+	overflow: visible !important;
+	box-sizing: border-box;
+	width: 40px !important;
+	height: 40px !important;
+}
+
+.bubbly-part.activitybar .action-item.checked .action-label.codicon {
+	background: var(--vscode-toolbar-hoverBackground) !important;
+	border: 1px solid var(--insert-border-color);
+}
+
+.bubbly-part.activitybar .active-item-indicator::before {
+	border-left-color: transparent !important;
+}
+
+.bubbly-part.activitybar .actions-container .action-item {
+	align-items: center;
+	justify-content: center;
+	display: flex !important;
 }

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -73,7 +73,7 @@
 	border-top-width: 0 !important;
 }
 
-.bubbly-part.panel .action-item {
+.bubbly-part.panel .composite-bar-container .action-item {
 	background-color: var(--vscode-toolbar-hoverBackground);
 	border-radius: var(--bubbly-radius-base);
 	/*padding: 2px;*/
@@ -82,6 +82,36 @@
 	transition: background-color 0.05s linear;
 	display: flex;
 	align-items: center;
+}
+
+.bubbly-part.panel .global-actions .action-item {
+	background-color: var(--vscode-toolbar-hoverBackground);
+	border-radius: var(--bubbly-radius-base);
+	width: 28px;
+	height: 28px;
+	box-sizing: border-box;
+	transition: background-color 0.05s linear;
+	display: flex;
+	align-items: center;
+}
+
+.bubbly-part.panel .title-actions > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item {
+	background-color: var(--vscode-toolbar-hoverBackground);
+	border-radius: var(--bubbly-radius-base);
+	min-width: 28px;
+	min-height: 28px;
+	box-sizing: border-box;
+	transition: background-color 0.05s linear;
+	display: flex;
+	align-items: center;
+}
+
+.bubbly-part.panel .title-actions {
+	margin-right: 2px;
+}
+
+.bubbly-part.panel .global-actions .action-item:hover {
+	background-color: none;
 }
 
 .bubbly-part.panel .composite-bar-container .action-item {
@@ -223,16 +253,26 @@
 
 /* Activity bar (when on sidebar) */
 .bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
-	gap: 2px;
+	gap: 0px;
 }
 
 .bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
 	width: 28px;
-	height: 30px;
+	height: 28px;
 	align-items: center;
 	justify-content: center;
 	padding: 2px;
 	border-radius: var(--bubbly-radius-base);
+}
+
+.bubbly-part.pane-composite-part.sidebar > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon,
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
+	padding: 0 0px;
+}
+
+.bubbly-part.pane-composite-part.sidebar > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content,
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
+	margin-right: 2px;
 }
 
 .bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
@@ -252,11 +292,6 @@
 .bubbly-part.sidebar .composite.header {
 	height: 42px;
 	align-items: center;
-}
-
-.bubbly-part.sidebar .composite.header .action-item {
-	height: 30px !important;
-	width: 30px !important;
 }
 
 /* Activity bar (when on left side of screen, detached from sidebar) */

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -21,164 +21,26 @@
 	box-sizing: border-box;
 }
 
-/* Base UI elements */
+/* Global UI elements */
 .monaco-inputbox {
 	border-radius: var(--bubbly-radius-base);
 }
 
-/* Globally, pane titles won't be forced uppercase */
 .monaco-pane-view .pane > .pane-header > .title {
 	text-transform: var(--bubbly-text-transform) !important;
 }
 
-/* Styles - Panel (bottom bar) */
-.bubbly-part.part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
-	text-transform: var(--bubbly-text-transform) !important;
-	border-bottom-color: transparent !important;
-}
-
-.bubbly-part.part.panel .action-item > .active-item-indicator::before {
-	border-top-width: 0 !important;
-}
-
-.bubbly-part.part.panel .action-item {
-	background-color: var(--vscode-toolbar-hoverBackground);
-	border-radius: var(--bubbly-radius-base);
-	/*padding: 2px;*/
-	box-sizing: border-box;
-	height: 80% !important;
-	transition: background-color 0.05s linear;
-	display: flex;
-	align-items: center;
-}
-
-.bubbly-part.part.panel .composite-bar-container .action-item {
-	background-color: transparent;
-}
-
-.bubbly-part.part.panel .action-item:hover {
-	background-color: var(--vscode-toolbar-hoverBackground);
-}
-
-.bubbly-part.part.panel .action-item.checked {
-	background-color: var(--vscode-toolbar-hoverBackground);
-}
-
-.bubbly-part.part.panel .actions-container {
-	gap: 2px;
-}
-
-.bubbly-part .action-item:has(.monaco-select-box), .action-item:has(.monaco-inputbox) {
-	padding: 0 !important;
-	background: none !important;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.bubbly-part .monaco-select-box {
+.monaco-select-box {
 	border: none !important;
 	border-color: transparent !important;
+	border-radius: var(--bubbly-radius-base);
 }
 
-.bubbly-part .action-item .monaco-select-box, .action-item .monaco-inputbox {
-	background: var(--vscode-toolbar-hoverBackground) !important;
-}
-
-.bubbly-part.part.panel {
-	background: var(--vscode-editor-background) !important;
-	--vscode-panel-background: var(--vscode-editor-background);
-}
-
-.bubbly-part.part.panel .composite.title {
-	margin-top: 2px;
-}
-
-/* Terminal - style the terminal to be the same color as panel*/
-.bubbly-part .terminal .xterm-scrollable-element {
-	background-color: var(--vscode-editor-background) !important;
-}
-
-.bubbly-part .terminal-wrapper {
-	background: var(--vscode-editor-background);
-}
-
-/* Styles - Sash */
-/* Globally, we will hide the sash */
-.monaco-split-view2 > .sash-container > .monaco-sash {
+.monaco-split-view2 > .sash-container > .monaco-sash {/* Globally, we will hide the sash */
 	color: transparent;
 	background: transparent;
 	--vscode-sash-hoverBorder: var(--vscode-charts-blue);
 }
-
-/* Styles - Editor: tabs/files */
-.bubbly-part .bubbly-editor-parent {
-	background: var(--vscode-editorGroupHeader-tabsBackground);
-}
-
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
-	align-items: center;
-	gap: 3px;/* this adds a gap between the left side and right side when there are many editors open */
-}
-
-/* The container which holds the tabs and action bar thing on the right side */
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container {
-	height: calc(var(--editor-group-tab-height) + var(--editor-group-tab-padding) * 2);
-	align-items: center;
-	margin-left: 8px;
-	margin-right: 2px;
-	gap: 4px;
-}
-
-.bubbly-part.part.editor .actions-container {
-	gap: 6px;
-}
-
-.bubbly-part.part.editor .actions-container .action-item {
-	margin-right: 0 !important;
-}
-
-/* This is each file tab */
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab {
-	border-radius: var(--bubbly-radius-xl);
-	align-items: center;
-	border: 1px solid transparent !important;
-}
-
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
-	border: 0.5px solid var(--vscode-tab-unfocusedInactiveForeground, transparent) !important;
-}
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
-	background: transparent;
-}
-
-.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .editor-actions {
-	padding-left: 6px;
-	padding-right: 6px;
-	gap: 3px;
-	border-radius: var(--bubbly-radius-base);
-	background: var(--vscode-editorGroupHeader-tabsBackground);
-	margin-right: 8px;
-}
-
-.bubbly-part .tab-border-top-container {
-	height: 0 !important;
-	background-color: none !important;
-}
-
-.bubbly-part .tab-border-bottom-container {
-	background: none !important;
-}
-
-.bubbly-part .tabs-and-actions-container {
-	background: var(--vscode-editor-background);
-}
-
-.bubbly-part .tab {
-	border-right: none !important;
-}
-
-/* Styles - Sidebar */
 
 .bubbly-part .pane-header {
 	background-color: transparent !important;
@@ -192,19 +54,160 @@
 	border: none !important;
 }
 
-.bubbly-part.sidebar .composite.title {
-	/*height: 28px;*/
+.bubbly-part/*.sidebar*/ .scrollbar > .slider {
+	border-radius: var(--bubbly-radius-base);
+}
+
+.bubbly-part .monaco-list-row {
+	border-radius: var(--bubbly-radius-s);
+}
+
+
+/* Panel (bottom bar) */
+.bubbly-part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
+	text-transform: var(--bubbly-text-transform) !important;
+	border-bottom-color: transparent !important;
+}
+
+.bubbly-part.panel .action-item > .active-item-indicator::before {
+	border-top-width: 0 !important;
+}
+
+.bubbly-part.panel .action-item {
+	background-color: var(--vscode-toolbar-hoverBackground);
+	border-radius: var(--bubbly-radius-base);
+	/*padding: 2px;*/
+	box-sizing: border-box;
+	height: 80% !important;
+	transition: background-color 0.05s linear;
+	display: flex;
 	align-items: center;
 }
 
-.bubbly-part.sidebar .composite.title > .title-label > h2 {
+.bubbly-part.panel .composite-bar-container .action-item {
+	background-color: transparent;
+}
+
+.bubbly-part.panel .action-item:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.bubbly-part.panel .action-item.checked {
+	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.bubbly-part.panel .actions-container {
+	gap: 2px;
+}
+
+.bubbly-part.panel .action-item:has(.monaco-select-box), .action-item:has(.monaco-inputbox) {
+	padding: 0 !important;
+	background: none !important;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.bubbly-part.panel .action-item .monaco-select-box, .action-item .monaco-inputbox {
+	background: var(--vscode-toolbar-hoverBackground) !important;
+}
+
+.bubbly-part.panel {
+	background: var(--vscode-editor-background) !important;
+	--vscode-panel-background: var(--vscode-editor-background);
+}
+
+.bubbly-part.panel .composite.title {
+	margin-top: 2px;
+}
+
+/* Terminal */
+.bubbly-part .terminal .xterm-scrollable-element {
+	background-color: var(--vscode-editor-background) !important;
+}
+
+.bubbly-part .terminal-wrapper {
+	background: var(--vscode-editor-background);
+}
+
+/* Editor - tabs/files */
+.bubbly-part .bubbly-editor-parent {
+	background: var(--vscode-editorGroupHeader-tabsBackground);
+}
+
+.monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
+	align-items: center;
+	gap: 3px;/* this adds a gap between the left side and right side when there are many editors open */
+}
+
+.monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-container {/* The 3-2 little actions on top right */
+	height: calc(var(--editor-group-tab-height) + var(--editor-group-tab-padding) * 2);
+	align-items: center;
+	margin-left: 8px;
+	margin-right: 2px;
+	gap: 4px;
+}
+
+.bubbly-part.editor .tabs-and-actions-container .actions-container {
+	gap: 6px;
+}
+
+.bubbly-part.editor .tabs-and-actions-container .actions-container .action-item {
+	margin-right: 0 !important;
+}
+
+.bubbly-part.editor > .content .editor-group-container > .title .tabs-container > .tab {
+	border-radius: var(--bubbly-radius-xl);
+	align-items: center;
+	border: 1px solid transparent !important;
+}
+
+.bubbly-part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
+	border: 0.5px solid var(--vscode-tab-unfocusedInactiveForeground, transparent) !important;
+}
+
+.bubbly-part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
+	background: transparent;
+}
+
+.bubbly-part.editor > .content .editor-group-container > .title .editor-actions {
+	padding-left: 6px;
+	padding-right: 6px;
+	gap: 3px;
+	border-radius: var(--bubbly-radius-base);
+	background: var(--vscode-editorGroupHeader-tabsBackground);
+	margin-right: 8px;
+}
+
+.bubbly-part.editor .tab-border-top-container {
+	background: none !important;
+}
+
+.bubbly-part.editor .tab-border-bottom-container {
+	background: none !important;
+}
+
+.bubbly-part.editor .tabs-and-actions-container {
+	background: var(--vscode-editor-background);
+}
+
+.bubbly-part.editor .tab {
+	border-right: none !important;
+}
+
+/* Sidebar */
+.bubbly-part.sidebar .composite.title {
+	align-items: center;
+}
+
+.bubbly-part.sidebar > .composite.title > .title-label > h2 {
 	line-height: 28px;
 	font-size: 11.5px;
 	font-weight: 700;
 	text-transform: var(--bubbly-text-transform);
 }
 
-.bubbly-part.sidebar .composite.title .title-actions {
+.bubbly-part.sidebar > .composite.title .title-actions {
 	height: 25px;
 }
 
@@ -213,26 +216,17 @@
 }
 
 /* Explorer */
-.bubbly-part.sidebar .monaco-highlighted-label {
+.part.sidebar .monaco-highlighted-label {
 	font-weight: 500;
 	font-size: 13px;/* was 13 */
 }
 
-.bubbly-part/*.sidebar*/ .scrollbar > .slider {
-	border-radius: var(--bubbly-radius-base);
-}
-
-.bubbly-part.sidebar .monaco-list-row {
-	border-radius: var(--bubbly-radius-s);
-}
-
-/* Styles - Activity bar (when on sidebar)*/
-.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
+/* Activity bar (when on sidebar) */
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
 	gap: 2px;
 }
 
-/* This is each little icon on the top of the sidebar */
-.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
 	width: 28px;
 	height: 30px;
 	align-items: center;
@@ -241,16 +235,16 @@
 	border-radius: var(--bubbly-radius-base);
 }
 
-.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
 	background: var(--vscode-toolbar-hoverBackground) !important;
 }
 
-.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	height: 0;
 	width: 0;
 }
 
-.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
+.bubbly-part.pane-composite-part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
 	left: 0;
 	position: relative;
 }
@@ -265,8 +259,8 @@
 	width: 30px !important;
 }
 
-/* Styles - Activity bar (when on left side of screen, detached from sidebar) */
-.monaco-workbench .bubbly-part.part.activitybar {
+/* Activity bar (when on left side of screen, detached from sidebar) */
+.monaco-workbench .bubbly-part.activitybar {
 	background-color: transparent !important;
 	color: transparent !important;
 }
@@ -316,8 +310,6 @@
 }
 
 /* Remove borders from some of the parts which aren't bubbly */
-
-/* Status bar */
 .part.statusbar.status-border-top::after {
 	background-color: transparent !important;
 }

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -170,12 +170,25 @@
 	gap: 3px;/* this adds a gap between the left side and right side when there are many editors open */
 }
 
-.monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-container {/* The 3-2 little actions on top right */
-	height: calc(var(--editor-group-tab-height) + var(--editor-group-tab-padding) * 2);
+.monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-container {
+	padding-top: var(--editor-group-tab-padding);
+	padding-bottom: var(--editor-group-tab-padding);
 	align-items: center;
 	margin-left: 8px;
 	margin-right: 2px;
 	gap: 4px;
+}
+
+.monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-and-actions-container.wrapping .tabs-container {
+	row-gap: 6px;
+}
+
+.bubbly-part.editor .tabs-and-actions-container.wrapping .tabs-container .tab.last-in-row:not(:last-child) {
+	flex-grow: 0 !important;
+}
+
+.bubbly-part.editor .tabs-and-actions-container.wrapping .editor-actions {
+	bottom: 8px !important;
 }
 
 .bubbly-part.editor .tabs-and-actions-container .actions-container {

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -163,7 +163,6 @@
 
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
 	background: var(--vscode-toolbar-hoverBackground) !important;
-	border: 1px solid var(--vscode-activityBarTop-activeBorder);
 }
 
 .bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -11,10 +11,6 @@
 	--bubbly-text-transform: uppercase;
 }
 
-.bubbly-part-pad {
-	margin: 5px;
-}
-
 .split-view-view:has(> .bubbly-part) {
 	background: var(--vscode-sideBar-background);
 }
@@ -78,7 +74,7 @@
 }
 
 /* Panel (bottom bar) */
-.bubbly-part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
+.bubbly-part.panel .action-label {/* panel buttons (Problems, Output, Debug Console)*/
 	text-transform: var(--bubbly-text-transform) !important;
 	border-bottom-color: transparent !important;
 }
@@ -91,29 +87,7 @@
 	background-color: var(--vscode-toolbar-hoverBackground);
 	border-radius: var(--bubbly-radius-base);
 	box-sizing: border-box;
-	height: 80% !important;
-	transition: background-color 0.05s linear;
-	display: flex;
-	align-items: center;
-}
-
-.bubbly-part.panel .global-actions .action-item {
-	background-color: var(--vscode-toolbar-hoverBackground);
-	border-radius: var(--bubbly-radius-base);
-	width: 28px;
-	height: 28px;
-	box-sizing: border-box;
-	transition: background-color 0.05s linear;
-	display: flex;
-	align-items: center;
-}
-
-.bubbly-part.panel .title-actions > .monaco-toolbar > .monaco-action-bar > .actions-container > .action-item {
-	background-color: var(--vscode-toolbar-hoverBackground);
-	border-radius: var(--bubbly-radius-base);
-	min-width: 28px;
-	min-height: 28px;
-	box-sizing: border-box;
+	height: 100% !important;
 	transition: background-color 0.05s linear;
 	display: flex;
 	align-items: center;
@@ -121,10 +95,6 @@
 
 .bubbly-part.panel .title-actions {
 	margin-right: 2px;
-}
-
-.bubbly-part.panel .global-actions .action-item:hover {
-	background-color: none;
 }
 
 .bubbly-part.panel .composite-bar-container .action-item {
@@ -137,6 +107,10 @@
 
 .bubbly-part.panel .action-item.checked {
 	background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.bubbly-part.panel .composite-bar .actions-container {
+	gap: 4px;
 }
 
 .bubbly-part.panel .actions-container {
@@ -161,7 +135,8 @@
 }
 
 .bubbly-part.panel .composite.title {
-	margin-top: 2px;
+	padding: 8px;
+	height: 51px;/* updated title size to account for padding, see layoutService.ts*/
 }
 
 /* Terminal */
@@ -189,7 +164,7 @@
 	align-items: center;
 	margin-left: 8px;
 	margin-right: 2px;
-	gap: 4px;
+	gap: 8px;
 }
 
 .monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-and-actions-container.wrapping .tabs-container {
@@ -315,11 +290,10 @@
 
 /* Activity bar (when on left side of screen, detached from sidebar) */
 .monaco-workbench .bubbly-part.activitybar {
-	background-color: transparent !important;
 	color: transparent !important;
 }
 
-.monaco-workbench .part.activitybar {/* Updated in code, see activitybarPart.ts */
+.monaco-workbench .part.activitybar {/* Updated width in code, see activitybarPart.ts */
 	width: 56px;
 }
 

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,4 +1,4 @@
-/* Base - bubbly parts */
+/* Bubbly parts */
 .bubbly-part {
 	box-sizing: border-box;
 }
@@ -18,6 +18,11 @@
 .bubbly-part .bubbly-editor-content {
 	border-radius: 10px;
 	box-sizing: border-box;
+}
+
+/* Base UI elements */
+.monaco-inputbox {
+	border-radius: 6px;
 }
 
 /* Styles - Panel (bottom bar) */

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -74,7 +74,7 @@
 }
 
 /* Panel (bottom bar) */
-.bubbly-part.panel .action-label {/* panel buttons (Problems, Output, Debug Console)*/
+.bubbly-part.panel .composite.title .composite-bar-container .monaco-action-bar .action-label {/* panel buttons (Problems, Output, Debug Console)*/
 	text-transform: var(--bubbly-text-transform) !important;
 	border-bottom-color: transparent !important;
 }
@@ -136,8 +136,12 @@
 
 .bubbly-part.panel .composite.title {
 	padding: 8px;
-	padding-right: 12px;
-	height: 51px;/* updated title size to account for padding, see layoutService.ts*/
+	padding-right: 10px;
+	height: 46px;/* updated title size to account for padding, see layoutService.ts*/
+}
+
+.bubbly-part.panel .title-actions {
+	align-self: center;
 }
 
 /* Terminal */
@@ -169,7 +173,7 @@
 }
 
 .monaco-workbench .bubbly-part.editor > .content .editor-group-container > .title .tabs-and-actions-container.wrapping .tabs-container {
-	row-gap: 6px;
+	row-gap: 8px;
 }
 
 .bubbly-part.editor .tabs-and-actions-container.wrapping .tabs-container .tab.last-in-row:not(:last-child) {

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,0 +1,156 @@
+.bubbly-part {
+	border-radius: 12px;
+	box-sizing: border-box;
+	margin: 5px;
+}
+
+.split-view-view:has(> .bubbly-part) {
+	background: var(--vscode-sideBar-background);
+}
+
+.bubbly-part .bubbly-editor-content {
+	border-radius: 10px;
+	box-sizing: border-box;
+}
+
+/* Panel styling */
+
+.bubbly-part .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/
+	text-transform: none !important;
+}
+
+.bubbly-part.part.panel .action-item {
+	background: var(--vscode-toolbar-hoverBackground);
+	border-radius: 8px;
+	padding: 2px;
+	box-sizing: border-box;
+	height: 80% !important;
+}
+
+.bubbly-part.part.panel .actions-container {
+	gap: 2px;
+}
+
+.bubbly-part .action-item:has(.monaco-select-box), .action-item:has(.monaco-inputbox) {
+	padding: 0 !important;
+	background: none !important;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.bubbly-part .action-item .monaco-select-box, .action-item .monaco-inputbox {
+	background: var(--vscode-toolbar-hoverBackground) !important;
+}
+
+/* Sash */
+/* Globally, we will hide the sash */
+.monaco-split-view2 > .sash-container > .monaco-sash {
+	color: transparent;
+	background: transparent;
+}
+
+/* Editor tabs/files */
+
+.bubbly-part .bubbly-editor-parent {
+	background: var(--vscode-editorGroupHeader-tabsBackground);
+}
+
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title > .tabs-and-actions-container {
+	align-items: center;
+	gap: 3px;
+}
+
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container {
+	height: calc(var(--editor-group-tab-height) + var(--editor-group-tab-padding) * 2);
+	align-items: center;
+	margin-left: 4px;
+	margin-right: 4px;
+	padding-left: 4px;
+	padding-right: 4px;
+}
+
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab {
+	border-radius: 10px;
+	margin-left: 3px;
+	margin-right: 3px;
+	align-items: center;
+	border: 1px solid transparent !important;
+}
+
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
+	background-color: var(--vscode-tab-unfocusedActiveBackground);
+	border: 1px solid var(--tab-border-top-color, transparent) !important;
+}
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active {
+	background: transparent;
+	/*box-shadow: 0px 0px 3px 1px var(--tab-border-top-color)*/
+}
+
+.monaco-workbench .bubbly-part.part.editor > .content .editor-group-container > .title .editor-actions {
+	padding-left: 6px;
+	padding-right: 6px;
+	gap: 3px;
+	border-radius: 6px;
+	background: var(--vscode-editorGroupHeader-tabsBackground);
+	margin-right: 8px;
+}
+
+.bubbly-part .tab-border-top-container {
+	height: 0 !important;
+	background-color: none !important;
+}
+
+.bubbly-part .tab-border-bottom-container {
+	background: none !important;
+}
+
+.bubbly-part .tabs-and-actions-container {
+	background: var(--vscode-editor-background);
+}
+
+.bubbly-part .tab {
+	border-right: none !important;
+}
+
+/* Sidebar stylings */
+
+.bubbly-part .pane-header {
+	background-color: transparent !important;
+}
+
+.bubbly-part {
+	border: none !important;
+}
+
+.bubbly-part .composite {
+	border: none !important;
+}
+
+.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar  .actions-container {
+	gap: 2px;
+}
+
+.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .codicon {
+	width: 22px;
+	height: 26px;
+	align-items: center;
+	justify-content: center;
+	padding: 2px;
+	border-radius: 6px;
+}
+
+.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .codicon {
+	background: var(--vscode-toolbar-hoverBackground) !important;
+	border: 1px solid var(--vscode-activityBarTop-activeBorder);
+}
+
+.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+	height: 0;
+	width: 0;
+}
+
+.bubbly-part.pane-composite-part.part.sidebar > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label::before {
+	left: 0;
+	position: relative;
+}

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -1,6 +1,9 @@
 /* Bubbly parts */
 .bubbly-part {
 	box-sizing: border-box;
+}
+
+:root {
 	--bubbly-radius-s: 4px;
 	--bubbly-radius-base: 6px;/* The main radius - used on most elements */
 	--bubbly-radius-l: 8px;
@@ -62,6 +65,17 @@
 	border-radius: var(--bubbly-radius-s);
 }
 
+/* Notifications */
+.monaco-workbench > .notifications-toasts .notifications-list-container,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast, .monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-scrollable-element,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-list:not(.element-focused):focus:before,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-list-row {
+	border-radius: var(--bubbly-radius-xl) !important;
+}
+
+.notification-list-item-buttons-container .monaco-button {
+	border-radius: var(--bubbly-radius-base);
+}
 
 /* Panel (bottom bar) */
 .bubbly-part.panel .action-label {/* Makes panel buttons (Problems, Output, Debug Console) not upcase*/

--- a/src/vs/workbench/browser/media/bubbly.css
+++ b/src/vs/workbench/browser/media/bubbly.css
@@ -229,3 +229,14 @@
 	justify-content: center;
 	display: flex !important;
 }
+
+/* Remove borders from some of the parts which aren't bubbly */
+
+/* Status bar */
+.part.statusbar.status-border-top::after {
+	background-color: transparent !important;
+}
+
+.part.auxiliarybar {
+	border-left: none !important;
+}

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -255,7 +255,10 @@ class PartLayout {
 		// Title Size: Width (Fill), Height (Variable)
 		let titleSize: Dimension;
 		if (this.options.hasTitle) {
-			titleSize = new Dimension(width, Math.min(height, PartLayout.TITLE_HEIGHT));
+			const titleHeight = (this.bubblySettings && this.bubblySettings.customTitleHeight)
+				? this.bubblySettings.customTitleHeight
+				: PartLayout.TITLE_HEIGHT;
+			titleSize = new Dimension(width, Math.min(height, titleHeight));
 		} else {
 			titleSize = Dimension.None;
 		}
@@ -263,7 +266,10 @@ class PartLayout {
 		// Header Size: Width (Fill), Height (Variable)
 		let headerSize: Dimension;
 		if (this.headerVisible) {
-			headerSize = new Dimension(width, Math.min(height, PartLayout.HEADER_HEIGHT));
+			const headerHeight = (this.bubblySettings && this.bubblySettings.customHeaderHeight)
+				? this.bubblySettings.customHeaderHeight
+				: PartLayout.HEADER_HEIGHT;
+			headerSize = new Dimension(width, Math.min(height, headerHeight));
 		} else {
 			headerSize = Dimension.None;
 		}

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -10,7 +10,7 @@ import { Dimension, size, IDimension, getActiveDocument, prepend, IDomPosition }
 import { IStorageService } from '../../platform/storage/common/storage.js';
 import { ISerializableView, IViewSize } from '../../base/browser/ui/grid/grid.js';
 import { Event, Emitter } from '../../base/common/event.js';
-import { bubblyParts, IWorkbenchLayoutService } from '../services/layout/browser/layoutService.js';
+import { bubblyParts, BubblyPartSettings, IWorkbenchLayoutService } from '../services/layout/browser/layoutService.js';
 import { assertIsDefined } from '../../base/common/types.js';
 import { IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 
@@ -76,14 +76,19 @@ export abstract class Part extends Component implements ISerializableView {
 	 */
 	create(parent: HTMLElement, options?: object): void {
 		this.parent = parent;
-		const isBubbly = bubblyParts.has(this.getId());
-		if (isBubbly)
+		const bubblySettings = bubblyParts[parent.id];
+		if (bubblySettings) {
 			this.parent.classList.add('bubbly-part');
+			if (bubblySettings.shouldPad)
+				this.parent.classList.add('bubbly-part-pad');
+			if (bubblySettings.shouldRound)
+				this.parent.classList.add('bubbly-part-round');
+		}
 
 		this.titleArea = this.createTitleArea(parent, options);
 		this.contentArea = this.createContentArea(parent, options);
 
-		this.partLayout = new PartLayout(this.options, this.contentArea, isBubbly);
+		this.partLayout = new PartLayout(this.options, this.contentArea, bubblySettings);
 
 		this.updateStyles();
 	}
@@ -238,10 +243,10 @@ class PartLayout {
 	private headerVisible: boolean = false;
 	private footerVisible: boolean = false;
 
-	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined, private isBubbly: boolean = false) { }
+	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined, private bubblySettings: BubblyPartSettings | undefined = undefined) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
-		if (this.isBubbly) {
+		if (this.bubblySettings && this.bubblySettings.shouldPad) {
 			height = height - 10;
 			width = width - 10;
 		}

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -10,7 +10,7 @@ import { Dimension, size, IDimension, getActiveDocument, prepend, IDomPosition }
 import { IStorageService } from '../../platform/storage/common/storage.js';
 import { ISerializableView, IViewSize } from '../../base/browser/ui/grid/grid.js';
 import { Event, Emitter } from '../../base/common/event.js';
-import { IWorkbenchLayoutService } from '../services/layout/browser/layoutService.js';
+import { bubblyParts, IWorkbenchLayoutService } from '../services/layout/browser/layoutService.js';
 import { assertIsDefined } from '../../base/common/types.js';
 import { IDisposable, toDisposable } from '../../base/common/lifecycle.js';
 
@@ -76,10 +76,14 @@ export abstract class Part extends Component implements ISerializableView {
 	 */
 	create(parent: HTMLElement, options?: object): void {
 		this.parent = parent;
+		const isBubbly = bubblyParts.has(this.getId());
+		if (isBubbly)
+			this.parent.classList.add('bubbly-part');
+
 		this.titleArea = this.createTitleArea(parent, options);
 		this.contentArea = this.createContentArea(parent, options);
 
-		this.partLayout = new PartLayout(this.options, this.contentArea);
+		this.partLayout = new PartLayout(this.options, this.contentArea, isBubbly);
 
 		this.updateStyles();
 	}
@@ -234,9 +238,13 @@ class PartLayout {
 	private headerVisible: boolean = false;
 	private footerVisible: boolean = false;
 
-	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined) { }
+	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined, private isBubbly: boolean = false) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
+		if (this.isBubbly) {
+			height = height - 10;
+			width = width - 10;
+		}
 
 		// Title Size: Width (Fill), Height (Variable)
 		let titleSize: Dimension;

--- a/src/vs/workbench/browser/part.ts
+++ b/src/vs/workbench/browser/part.ts
@@ -79,10 +79,11 @@ export abstract class Part extends Component implements ISerializableView {
 		const bubblySettings = bubblyParts[parent.id];
 		if (bubblySettings) {
 			this.parent.classList.add('bubbly-part');
-			if (bubblySettings.shouldPad)
-				this.parent.classList.add('bubbly-part-pad');
-			if (bubblySettings.shouldRound)
-				this.parent.classList.add('bubbly-part-round');
+			this.parent.style.marginLeft = `${bubblySettings.margins.left}px`;
+			this.parent.style.marginTop = `${bubblySettings.margins.top}px`;
+			this.parent.style.marginRight = `${bubblySettings.margins.right}px`;
+			this.parent.style.marginBottom = `${bubblySettings.margins.bottom}px`;
+			this.parent.style.borderRadius = `${bubblySettings.borderRadius}px`;
 		}
 
 		this.titleArea = this.createTitleArea(parent, options);
@@ -246,9 +247,9 @@ class PartLayout {
 	constructor(private options: IPartOptions, private contentArea: HTMLElement | undefined, private bubblySettings: BubblyPartSettings | undefined = undefined) { }
 
 	layout(width: number, height: number): ILayoutContentResult {
-		if (this.bubblySettings && this.bubblySettings.shouldPad) {
-			height = height - 10;
-			width = width - 10;
+		if (this.bubblySettings) {
+			width = width - this.bubblySettings.margins.left - this.bubblySettings.margins.right;
+			height = height - this.bubblySettings.margins.top - this.bubblySettings.margins.bottom;
 		}
 
 		// Title Size: Width (Fill), Height (Variable)

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -49,8 +49,10 @@ export class ActivitybarPart extends Part {
 
 	//#region IView
 
-	readonly minimumWidth: number = 48;
-	readonly maximumWidth: number = 48;
+	// Bubbly - width is now 56 (prev. 48)
+	readonly minimumWidth: number = 56;
+	readonly maximumWidth: number = 56;
+
 	readonly minimumHeight: number = 0;
 	readonly maximumHeight: number = Number.POSITIVE_INFINITY;
 

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -972,8 +972,11 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 
 		// Container
 		this.element = parent;
+		this.element.classList.add('bubbly-editor-parent');
 		this.container = document.createElement('div');
 		this.container.classList.add('content');
+		this.container.classList.add('bubbly-editor-content')
+
 		if (this.windowId !== mainWindow.vscodeWindowId) {
 			this.container.classList.add('auxiliary');
 		}

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -101,8 +101,8 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 	private static readonly EDITOR_TAB_PADDING_PX = 8;
 	private static readonly EDITOR_TAB_HEIGHT = {
-		normal: 50 as const,// was 35
-		compact: 40 as const,// was 22
+		normal: (35 + this.EDITOR_TAB_PADDING_PX * 2),
+		compact: (22 + this.EDITOR_TAB_PADDING_PX * 2),
 	};
 
 	protected editorActionsToolbarContainer: HTMLElement | undefined;

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -99,9 +99,10 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	protected readonly groupTransfer = LocalSelectionTransfer.getInstance<DraggedEditorGroupIdentifier>();
 	protected readonly treeItemsTransfer = LocalSelectionTransfer.getInstance<DraggedTreeItemsIdentifier>();
 
+	private static readonly EDITOR_TAB_PADDING_PX = 8;
 	private static readonly EDITOR_TAB_HEIGHT = {
-		normal: 35 as const,
-		compact: 22 as const
+		normal: 50 as const,// was 35
+		compact: 40 as const,// was 22
 	};
 
 	protected editorActionsToolbarContainer: HTMLElement | undefined;
@@ -464,7 +465,8 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 	}
 
 	protected updateTabHeight(): void {
-		this.parent.style.setProperty('--editor-group-tab-height', `${this.tabHeight}px`);
+		this.parent.style.setProperty('--editor-group-tab-padding', `${EditorTabsControl.EDITOR_TAB_PADDING_PX}px`);
+		this.parent.style.setProperty('--editor-group-tab-height', `${this.tabHeight - (EditorTabsControl.EDITOR_TAB_PADDING_PX) * 2}px`);
 	}
 
 	updateOptions(oldOptions: IEditorPartOptions, newOptions: IEditorPartOptions): void {

--- a/src/vs/workbench/browser/style.ts
+++ b/src/vs/workbench/browser/style.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './media/style.css';
+import './media/bubbly.css';
 import { registerThemingParticipant } from '../../platform/theme/common/themeService.js';
 import { WORKBENCH_BACKGROUND, TITLE_BAR_ACTIVE_BACKGROUND } from '../common/theme.js';
 import { isWeb, isIOS } from '../../base/common/platform.js';

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -605,9 +605,9 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.hover.delay': {
 				'type': 'number',
 				'description': localize('workbench.hover.delay', "Controls the delay in milliseconds after which the hover is shown for workbench items (ex. some extension provided tree view items). Already visible items may require a refresh before reflecting this setting change."),
-				// Testing has indicated that on Windows and Linux 500 ms matches the native hovers most closely.
-				// On Mac, the delay is 1500.
-				'default': isMacintosh ? 1500 : 500,
+				// Previously 500 on all platforms, then 1500 on macOS
+				// Changed to 200 because both are way too long
+				'default': 200,
 				'minimum': 0
 			},
 			'workbench.reduceMotion': {

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -77,7 +77,7 @@ import { asCssVariable } from '../../../../../platform/theme/common/colorUtils.j
 
 export class ExplorerDelegate implements IListVirtualDelegate<ExplorerItem> {
 
-	static readonly ITEM_HEIGHT = 22;
+	static readonly ITEM_HEIGHT = 23;//22;
 
 	getHeight(element: ExplorerItem): number {
 		return ExplorerDelegate.ITEM_HEIGHT;

--- a/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
@@ -6,7 +6,7 @@
 import { editorOverviewRulerBorder } from '../../../../editor/common/core/editorColorRegistry.js';
 import * as nls from '../../../../nls.js';
 
-import { registerColor, ColorIdentifier, ColorDefaults, editorFindMatch, editorFindMatchHighlight, overviewRulerFindMatchForeground, editorSelectionBackground, transparent, editorHoverHighlight } from '../../../../platform/theme/common/colorRegistry.js';
+import { registerColor, ColorIdentifier, ColorDefaults, editorFindMatch, editorFindMatchHighlight, overviewRulerFindMatchForeground, editorSelectionBackground, transparent, editorHoverHighlight, editorBackground } from '../../../../platform/theme/common/colorRegistry.js';
 import { EDITOR_DRAG_AND_DROP_BACKGROUND, PANEL_BORDER, TAB_ACTIVE_BORDER } from '../../../common/theme.js';
 
 /**
@@ -15,7 +15,8 @@ import { EDITOR_DRAG_AND_DROP_BACKGROUND, PANEL_BORDER, TAB_ACTIVE_BORDER } from
  */
 export const ansiColorIdentifiers: ColorIdentifier[] = [];
 
-export const TERMINAL_BACKGROUND_COLOR = registerColor('terminal.background', null, nls.localize('terminal.background', 'The background color of the terminal, this allows coloring the terminal differently to the panel.'));
+//export const TERMINAL_BACKGROUND_COLOR = registerColor('terminal.background', null, nls.localize('terminal.background', 'The background color of the terminal, this allows coloring the terminal differently to the panel.'));
+export const TERMINAL_BACKGROUND_COLOR = editorBackground;
 export const TERMINAL_FOREGROUND_COLOR = registerColor('terminal.foreground', {
 	light: '#333333',
 	dark: '#CCCCCC',

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -51,7 +51,7 @@ export const bubblyParts: Record<string, BubblyPartSettings> = {
 	},
 	[Parts.PANEL_PART]: {
 		...defaultBubblySettings,
-		customTitleHeight: 51
+		customTitleHeight: 46
 	},
 	[Parts.EDITOR_PART]: defaultBubblySettings,
 	[Parts.PEAROVERLAY_PART]: {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -49,7 +49,10 @@ export const bubblyParts: Record<string, BubblyPartSettings> = {
 		customHeaderHeight: 42,
 		borderRadius: 0
 	},
-	[Parts.PANEL_PART]: defaultBubblySettings,
+	[Parts.PANEL_PART]: {
+		...defaultBubblySettings,
+		customTitleHeight: 51
+	},
 	[Parts.EDITOR_PART]: defaultBubblySettings,
 	[Parts.PEAROVERLAY_PART]: {
 		borderRadius: 0,

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -35,11 +35,14 @@ export interface BubblyPartSettings {
 	borderRadius: number,
 }
 const defaultBubblySettings: BubblyPartSettings = {
-	margins: { left: 4, top: 4, right: 4, bottom: 4 },
-	borderRadius: 12,
+	margins: { left: 4, top: 4, right: 4, bottom: 4 },//testing 4 2 4 2
+	borderRadius: 10,//--bubbly-radius-xl
 }
 export const bubblyParts: Record<string, BubblyPartSettings> = {
-	[Parts.SIDEBAR_PART]: {margins: {left: 4, top: 7, bottom: 5, right: 4}, borderRadius: 0},
+	[Parts.SIDEBAR_PART]: {
+		margins: defaultBubblySettings.margins,
+		borderRadius: 0
+	},
 	[Parts.PANEL_PART]: defaultBubblySettings,
 	[Parts.EDITOR_PART]: defaultBubblySettings,
 	[Parts.PEAROVERLAY_PART]: defaultBubblySettings,

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -30,12 +30,21 @@ export const enum Parts {
 	PEAROVERLAY_PART = 'workbench.parts.pearoverlay'
 }
 
-export const bubblyParts = new Set([
-	Parts.SIDEBAR_PART,
-	Parts.PANEL_PART,
-	Parts.EDITOR_PART,
-	Parts.PEAROVERLAY_PART
-] as string[]);
+export interface BubblyPartSettings {
+	shouldPad: boolean,
+	shouldRound: boolean,
+}
+const defaultBubblySettings = {
+	shouldPad: true,
+	shouldRound: false,
+}
+export const bubblyParts: Record<string, BubblyPartSettings> = {
+	[Parts.SIDEBAR_PART]: defaultBubblySettings,
+	[Parts.PANEL_PART]: defaultBubblySettings,
+	[Parts.EDITOR_PART]: defaultBubblySettings,
+	[Parts.PEAROVERLAY_PART]: defaultBubblySettings,
+	[Parts.ACTIVITYBAR_PART]: { shouldPad: false, shouldRound: false}
+}
 
 export const enum ZenModeSettings {
 	SHOW_TABS = 'zenMode.showTabs',

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -51,7 +51,10 @@ export const bubblyParts: Record<string, BubblyPartSettings> = {
 	},
 	[Parts.PANEL_PART]: defaultBubblySettings,
 	[Parts.EDITOR_PART]: defaultBubblySettings,
-	[Parts.PEAROVERLAY_PART]: defaultBubblySettings,
+	[Parts.PEAROVERLAY_PART]: {
+		borderRadius: 0,
+		margins: {left: 0, top: 0, right: 0, bottom: 0}
+	},
 	[Parts.ACTIVITYBAR_PART]: { margins: { left: 0, top: 0, right: 0, bottom: 0 }, borderRadius: 0}
 }
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -30,6 +30,13 @@ export const enum Parts {
 	PEAROVERLAY_PART = 'workbench.parts.pearoverlay'
 }
 
+export const bubblyParts = new Set([
+	Parts.SIDEBAR_PART,
+	Parts.PANEL_PART,
+	Parts.EDITOR_PART,
+	Parts.PEAROVERLAY_PART
+] as string[]);
+
 export const enum ZenModeSettings {
 	SHOW_TABS = 'zenMode.showTabs',
 	HIDE_LINENUMBERS = 'zenMode.hideLineNumbers',

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -31,19 +31,19 @@ export const enum Parts {
 }
 
 export interface BubblyPartSettings {
-	shouldPad: boolean,
-	shouldRound: boolean,
+	margins: {left: number, top: number, right: number, bottom: number}
+	borderRadius: number,
 }
-const defaultBubblySettings = {
-	shouldPad: true,
-	shouldRound: true,
+const defaultBubblySettings: BubblyPartSettings = {
+	margins: { left: 4, top: 4, right: 4, bottom: 4 },
+	borderRadius: 12,
 }
 export const bubblyParts: Record<string, BubblyPartSettings> = {
-	[Parts.SIDEBAR_PART]: defaultBubblySettings,
+	[Parts.SIDEBAR_PART]: {margins: {left: 4, top: 7, bottom: 5, right: 4}, borderRadius: 0},
 	[Parts.PANEL_PART]: defaultBubblySettings,
 	[Parts.EDITOR_PART]: defaultBubblySettings,
 	[Parts.PEAROVERLAY_PART]: defaultBubblySettings,
-	[Parts.ACTIVITYBAR_PART]: { shouldPad: false, shouldRound: false}
+	[Parts.ACTIVITYBAR_PART]: { margins: { left: 0, top: 0, right: 0, bottom: 0 }, borderRadius: 0}
 }
 
 export const enum ZenModeSettings {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -33,14 +33,20 @@ export const enum Parts {
 export interface BubblyPartSettings {
 	margins: {left: number, top: number, right: number, bottom: number}
 	borderRadius: number,
+	customTitleHeight?: number,// default: 35
+	customHeaderHeight?: number,// default: 35
 }
+
 const defaultBubblySettings: BubblyPartSettings = {
-	margins: { left: 4, top: 4, right: 4, bottom: 4 },//testing 4 2 4 2
+	margins: { left: 4, top: 4, right: 4, bottom: 4 },
 	borderRadius: 10,//--bubbly-radius-xl
 }
+
 export const bubblyParts: Record<string, BubblyPartSettings> = {
 	[Parts.SIDEBAR_PART]: {
-		margins: defaultBubblySettings.margins,
+		margins: { left: 4, top: 4, right: 4, bottom: 4 },
+		customTitleHeight: 31,
+		customHeaderHeight: 42,
 		borderRadius: 0
 	},
 	[Parts.PANEL_PART]: defaultBubblySettings,

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -36,7 +36,7 @@ export interface BubblyPartSettings {
 }
 const defaultBubblySettings = {
 	shouldPad: true,
-	shouldRound: false,
+	shouldRound: true,
 }
 export const bubblyParts: Record<string, BubblyPartSettings> = {
 	[Parts.SIDEBAR_PART]: defaultBubblySettings,


### PR DESCRIPTION
[Make PearAI look more bubbly](https://github.com/orgs/trypear/projects/20/views/1?pane=issue&itemId=100908299&issue=trypear%7Cpearai-app%7C212)
I made PearAI more bubbly 🤪🤪🤪

(Dark Modern)
![Screenshot 2025-04-15 at 9 22 01 PM](https://github.com/user-attachments/assets/618c530d-2959-4e76-a2d5-64e5bfe75d58)
(Snazzy Light)
![Screenshot 2025-04-15 at 9 23 19 PM](https://github.com/user-attachments/assets/e5a13997-57a6-45b4-a25d-60c77718af95)

I made UI close to the mock, except for Explorer which is a kinda different. Haven't seen any bugs yet pray

Lmk what you think about the design and implementation.

Most changes are in a 'bubbly.css' where they add onto or sometimes modify existing styles. This was just easiest at the time, and I'm not sure if it would be better for the codebase to keep these styles separate in bubbly.css or not.

Lets gooooooooooooooo


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a new 'bubbly' UI style with rounded elements and updated layout logic for PearAI.
> 
>   - **UI Styling**:
>     - Introduces `bubbly.css` for new rounded UI styles, affecting border-radius and background colors.
>     - Applies `bubbly-part` class to `Part` in `part.ts` and `EditorPart` in `editorPart.ts` for rounded styles.
>     - Updates `editorTabsControl.ts` to adjust tab height and padding for bubbly appearance.
>   - **Layout Adjustments**:
>     - Modifies `PartLayout` in `part.ts` to reduce dimensions for bubbly parts.
>     - Updates `layoutService.ts` to include `bubblyParts` set for identifying bubbly components.
>   - **Misc**:
>     - Imports `bubbly.css` in `style.ts` for global application of new styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-app&utm_source=github&utm_medium=referral)<sup> for 1754988b8b97ac63d2a639bbcf64ba11c2ed97dd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->